### PR TITLE
chore: 🤖 allow nuke role in sandboxes to pull from shared s3

### DIFF
--- a/terraform/shared_account_sandbox_infra_ci/iam.tf
+++ b/terraform/shared_account_sandbox_infra_ci/iam.tf
@@ -1,8 +1,8 @@
 # tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "allow_sandbox_a_codebuild_bucket" {
   for_each = toset(["Bichard7-CI-Access", "Bichard7-Aws-Nuke-Access"])
-  name = "AllCodeBuildBucketAccess"
-  role = each.key
+  name     = "AllCodeBuildBucketAccess"
+  role     = each.key
 
   policy = <<-EOF
   {
@@ -39,8 +39,8 @@ resource "aws_iam_role_policy" "allow_sandbox_a_codebuild_bucket" {
 # tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "allow_sandbox_b_codebuild_bucket" {
   for_each = toset(["Bichard7-CI-Access", "Bichard7-Aws-Nuke-Access"])
-  name = "AllCodeBuildBucketAccess"
-  role = each.key
+  name     = "AllCodeBuildBucketAccess"
+  role     = each.key
 
   policy = <<-EOF
   {
@@ -77,8 +77,8 @@ resource "aws_iam_role_policy" "allow_sandbox_b_codebuild_bucket" {
 # tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "allow_sandbox_c_codebuild_bucket" {
   for_each = toset(["Bichard7-CI-Access", "Bichard7-Aws-Nuke-Access"])
-  name = "AllCodeBuildBucketAccess"
-  role = each.key
+  name     = "AllCodeBuildBucketAccess"
+  role     = each.key
 
   policy = <<-EOF
   {

--- a/terraform/shared_account_sandbox_infra_ci/iam.tf
+++ b/terraform/shared_account_sandbox_infra_ci/iam.tf
@@ -1,7 +1,8 @@
 # tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "allow_sandbox_a_codebuild_bucket" {
+  for_each = toset(["Bichard7-CI-Access", "Bichard7-Aws-Nuke-Access"])
   name = "AllCodeBuildBucketAccess"
-  role = "Bichard7-CI-Access"
+  role = each.key
 
   policy = <<-EOF
   {
@@ -37,8 +38,9 @@ resource "aws_iam_role_policy" "allow_sandbox_a_codebuild_bucket" {
 
 # tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "allow_sandbox_b_codebuild_bucket" {
+  for_each = toset(["Bichard7-CI-Access", "Bichard7-Aws-Nuke-Access"])
   name = "AllCodeBuildBucketAccess"
-  role = "Bichard7-CI-Access"
+  role = each.key
 
   policy = <<-EOF
   {
@@ -74,8 +76,9 @@ resource "aws_iam_role_policy" "allow_sandbox_b_codebuild_bucket" {
 
 # tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_role_policy" "allow_sandbox_c_codebuild_bucket" {
+  for_each = toset(["Bichard7-CI-Access", "Bichard7-Aws-Nuke-Access"])
   name = "AllCodeBuildBucketAccess"
-  role = "Bichard7-CI-Access"
+  role = each.key
 
   policy = <<-EOF
   {


### PR DESCRIPTION
Allows the sandbox nuke role to pull assets from the shared account  s3 bucket