### PR TITLE
Allow users with pending clearance access to prod

### DIFF
--- a/ansible/vars/users.yml
+++ b/ansible/vars/users.yml
@@ -39,9 +39,6 @@
       type: admin
 
 - non_sc_users:
-    - alice_lee
-    - tom_vaughan
-    - csaba_gyorfi
     - tolu_johnson
     - heather_roberts
     - joe_folkard


### PR DESCRIPTION
A waiver has been issued for engineers with a pending SC application, and these users should be able to access the production environment