### PR TITLE
fix: 🐛 ignore resource not found for deleted users

### DIFF
--- a/ansible/remove_users.yml
+++ b/ansible/remove_users.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: "Get user {{ user.name }}'s details from ssm"
+  ignore_errors: yes
   set_fact:
     user_name: "{{ lookup('aws_ssm', '/users/'+ user.name ) }}"
 

--- a/ansible/vars/users.yml
+++ b/ansible/vars/users.yml
@@ -31,19 +31,16 @@
       type: admin
     - name: tom_vaughan
       type: admin
-    - name: tolu_johnson
-      type: readonly
     - name: heather_roberts
       type: readonly
     - name: joe_folkard
       type: admin
 
 - non_sc_users:
-    - tolu_johnson
     - heather_roberts
-    - joe_folkard
 
 - users_removed:
+    - name: tolu_johnson
     - name: christopher_ryan
     - name: david_roberts
     - name: gurpinder_basi

--- a/terraform/shared_account_pathtolive_bootstrap/README.md
+++ b/terraform/shared_account_pathtolive_bootstrap/README.md
@@ -29,7 +29,7 @@ $ aws-vault exec bichard7-shared -- aws s3 cp terraform.tfstate s3://cjse-bichar
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.72.0 |
 
 ## Modules
 

--- a/terraform/shared_account_pathtolive_infra/README.md
+++ b/terraform/shared_account_pathtolive_infra/README.md
@@ -40,13 +40,13 @@ For the delegated hosted zone parent see [this readme](../shared_account_sandbox
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_aws.integration_baseline"></a> [aws.integration\_baseline](#provider\_aws.integration\_baseline) | 3.75.2 |
-| <a name="provider_aws.integration_next"></a> [aws.integration\_next](#provider\_aws.integration\_next) | 3.75.2 |
-| <a name="provider_aws.preprod"></a> [aws.preprod](#provider\_aws.preprod) | 3.75.2 |
-| <a name="provider_aws.production"></a> [aws.production](#provider\_aws.production) | 3.75.2 |
-| <a name="provider_aws.sandbox"></a> [aws.sandbox](#provider\_aws.sandbox) | 3.75.2 |
-| <a name="provider_aws.shared"></a> [aws.shared](#provider\_aws.shared) | 3.75.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.72.0 |
+| <a name="provider_aws.integration_baseline"></a> [aws.integration\_baseline](#provider\_aws.integration\_baseline) | 3.72.0 |
+| <a name="provider_aws.integration_next"></a> [aws.integration\_next](#provider\_aws.integration\_next) | 3.72.0 |
+| <a name="provider_aws.preprod"></a> [aws.preprod](#provider\_aws.preprod) | 3.72.0 |
+| <a name="provider_aws.production"></a> [aws.production](#provider\_aws.production) | 3.72.0 |
+| <a name="provider_aws.sandbox"></a> [aws.sandbox](#provider\_aws.sandbox) | 3.72.0 |
+| <a name="provider_aws.shared"></a> [aws.shared](#provider\_aws.shared) | 3.72.0 |
 
 ## Modules
 

--- a/terraform/shared_account_pathtolive_infra_ci/README.md
+++ b/terraform/shared_account_pathtolive_infra_ci/README.md
@@ -15,11 +15,11 @@ Creates various codebuild/codepipeline jobs and a codebuild vpc for our path to 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_aws.integration_baseline"></a> [aws.integration\_baseline](#provider\_aws.integration\_baseline) | 3.75.2 |
-| <a name="provider_aws.integration_next"></a> [aws.integration\_next](#provider\_aws.integration\_next) | 3.75.2 |
-| <a name="provider_aws.production"></a> [aws.production](#provider\_aws.production) | 3.75.2 |
-| <a name="provider_aws.qsolution"></a> [aws.qsolution](#provider\_aws.qsolution) | 3.75.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.72.0 |
+| <a name="provider_aws.integration_baseline"></a> [aws.integration\_baseline](#provider\_aws.integration\_baseline) | 3.72.0 |
+| <a name="provider_aws.integration_next"></a> [aws.integration\_next](#provider\_aws.integration\_next) | 3.72.0 |
+| <a name="provider_aws.production"></a> [aws.production](#provider\_aws.production) | 3.72.0 |
+| <a name="provider_aws.qsolution"></a> [aws.qsolution](#provider\_aws.qsolution) | 3.72.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.1.0 |
 | <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |

--- a/terraform/shared_account_pathtolive_infra_ci_monitoring/README.md
+++ b/terraform/shared_account_pathtolive_infra_ci_monitoring/README.md
@@ -15,7 +15,7 @@ Creates a Grafana ECS cluster that pulls metrics from Cloudwatch
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.72.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.2.2 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 

--- a/terraform/shared_account_sandbox_bootstrap/README.md
+++ b/terraform/shared_account_sandbox_bootstrap/README.md
@@ -29,7 +29,7 @@ $ aws-vault exec bichard7-sandbox-shared -- aws s3 cp terraform.tfstate s3://cjs
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.72.0 |
 
 ## Modules
 

--- a/terraform/shared_account_sandbox_infra/README.md
+++ b/terraform/shared_account_sandbox_infra/README.md
@@ -39,11 +39,11 @@ export TF_VAR_sandbox_c_secret_key=""
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_aws.sandbox_a"></a> [aws.sandbox\_a](#provider\_aws.sandbox\_a) | 3.75.2 |
-| <a name="provider_aws.sandbox_b"></a> [aws.sandbox\_b](#provider\_aws.sandbox\_b) | 3.75.2 |
-| <a name="provider_aws.sandbox_c"></a> [aws.sandbox\_c](#provider\_aws.sandbox\_c) | 3.75.2 |
-| <a name="provider_aws.sandbox_shared"></a> [aws.sandbox\_shared](#provider\_aws.sandbox\_shared) | 3.75.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.72.0 |
+| <a name="provider_aws.sandbox_a"></a> [aws.sandbox\_a](#provider\_aws.sandbox\_a) | 3.72.0 |
+| <a name="provider_aws.sandbox_b"></a> [aws.sandbox\_b](#provider\_aws.sandbox\_b) | 3.72.0 |
+| <a name="provider_aws.sandbox_c"></a> [aws.sandbox\_c](#provider\_aws.sandbox\_c) | 3.72.0 |
+| <a name="provider_aws.sandbox_shared"></a> [aws.sandbox\_shared](#provider\_aws.sandbox\_shared) | 3.72.0 |
 | <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
 
 ## Modules

--- a/terraform/shared_account_sandbox_infra_ci/README.md
+++ b/terraform/shared_account_sandbox_infra_ci/README.md
@@ -15,10 +15,10 @@ Creates various codebuild/codepipeline jobs and a codebuild vpc for our path to 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_aws.sandbox_a"></a> [aws.sandbox\_a](#provider\_aws.sandbox\_a) | 3.75.2 |
-| <a name="provider_aws.sandbox_b"></a> [aws.sandbox\_b](#provider\_aws.sandbox\_b) | 3.75.2 |
-| <a name="provider_aws.sandbox_c"></a> [aws.sandbox\_c](#provider\_aws.sandbox\_c) | 3.75.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.72.0 |
+| <a name="provider_aws.sandbox_a"></a> [aws.sandbox\_a](#provider\_aws.sandbox\_a) | 3.72.0 |
+| <a name="provider_aws.sandbox_b"></a> [aws.sandbox\_b](#provider\_aws.sandbox\_b) | 3.72.0 |
+| <a name="provider_aws.sandbox_c"></a> [aws.sandbox\_c](#provider\_aws.sandbox\_c) | 3.72.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.1.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 


### PR DESCRIPTION
Ansible started throwing fatal errors when a deleted user's ssm could not be found. We can safely ignore these errors because most of the time we expect them to be deleted.

Also:
- delete Tolu
- remove Joe from non_sc user group