### PR TITLE
feat: 🎸 add bichard7-next-ui to pipeline & build codebuild job

### DIFF
--- a/terraform/modules/shared_cd_common_jobs/build_core.tf
+++ b/terraform/modules/shared_cd_common_jobs/build_core.tf
@@ -8,29 +8,7 @@ module "build_core" {
   sns_kms_key_arn        = var.notifications_kms_key_arn
   vpc_config             = var.vpc_config_block
 
-  allowed_resource_arns = [
-    data.aws_ecr_repository.nodejs.arn
-  ]
-
-  environment_variables = concat(
-    [
-      {
-        name  = "ACCOUNT_ID"
-        value = data.aws_caller_identity.current.account_id
-      }
-    ],
-    var.audit_logging_cd_env_vars
-  )
-
-  build_environments = [
-    {
-      compute_type                = "BUILD_GENERAL1_MEDIUM"
-      image                       = "${data.aws_ecr_repository.nodejs.repository_url}@${data.external.latest_nodejs_image.result.tags}"
-      type                        = "LINUX_CONTAINER"
-      privileged_mode             = true
-      image_pull_credentials_type = "SERVICE_ROLE"
-    }
-  ]
+  environment_variables = var.core_cd_env_vars
 
   tags = var.tags
 }

--- a/terraform/modules/shared_cd_common_jobs/build_ui.tf
+++ b/terraform/modules/shared_cd_common_jobs/build_ui.tf
@@ -1,0 +1,19 @@
+module "build_bichard7_ui_docker_image" {
+  source                 = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job"
+  codepipeline_s3_bucket = var.codebuild_s3_bucket
+  sns_notification_arn   = var.sns_notifications_arn
+  sns_kms_key_arn        = var.notifications_kms_key_arn
+  vpc_config             = var.vpc_config_block
+  build_description      = "Codebuild for building the UI"
+  name                   = "build-ui-docker"
+  repository_name        = "bichard7-next-ui"
+
+  environment_variables = var.ui_cd_env_vars
+
+  tags = var.tags
+}
+
+module "build_bichard7_ui_docker_image_trigger" {
+  source                 = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_webhook"
+  codebuild_project_name = module.build_bichard7_ui_docker_image.pipeline_name
+}

--- a/terraform/modules/shared_cd_common_jobs/vars.tf
+++ b/terraform/modules/shared_cd_common_jobs/vars.tf
@@ -47,6 +47,18 @@ variable "user_service_cd_env_vars" {
   default     = []
 }
 
+variable "core_cd_env_vars" {
+  description = "A list of maps of env var strings"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "ui_cd_env_vars" {
+  description = "A list of maps of env var strings"
+  type        = list(map(string))
+  default     = []
+}
+
 variable "beanconnect_cd_env_vars" {
   description = "A list of maps of env var strings"
   type        = list(map(string))

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -27,6 +27,22 @@ resource "aws_codepipeline" "path_to_live" {
     }
 
     action {
+      name     = "ui-semaphore"
+      category = "Source"
+      owner    = "AWS"
+      provider = "S3"
+      version  = "1"
+
+      output_artifacts = ["ui-semaphore"]
+
+      configuration = {
+        S3Bucket             = module.codebuild_base_resources.codepipeline_bucket
+        S3ObjectKey          = "semaphores/ui.json"
+        PollForSourceChanges = true
+      }
+    }
+
+    action {
       name     = "user-service-semaphore"
       category = "Source"
       owner    = "AWS"
@@ -190,6 +206,10 @@ resource "aws_codepipeline" "path_to_live" {
             {
               name  = "TF_VAR_nginx_auth_proxy_deploy_tag"
               value = "#{HASHES.NGINX_AUTH_PROXY_IMAGE_HASH}"
+            },
+            {
+              name  = "TF_VAR_ui_deploy_tag"
+              value = "#{HASHES.UI_IMAGE_HASH}"
             }
           ]
         )
@@ -312,6 +332,10 @@ resource "aws_codepipeline" "path_to_live" {
             {
               name  = "NGINX_AUTH_PROXY_IMAGE_HASH"
               value = "#{HASHES.NGINX_AUTH_PROXY_IMAGE_HASH}"
+            },
+            {
+              name  = "UI_IMAGE_HASH"
+              value = "#{HASHES.UI_IMAGE_HASH}"
             }
           ]
         )
@@ -352,6 +376,10 @@ resource "aws_codepipeline" "path_to_live" {
             {
               name  = "TF_VAR_nginx_auth_proxy_deploy_tag"
               value = "#{HASHES.NGINX_AUTH_PROXY_IMAGE_HASH}"
+            },
+            {
+              name  = "TF_VAR_ui_deploy_tag"
+              value = "#{HASHES.UI_IMAGE_HASH}"
             }
           ]
         )
@@ -460,6 +488,10 @@ resource "aws_codepipeline" "path_to_live" {
             {
               name  = "NGINX_AUTH_PROXY_COMMIT_HASH"
               value = "#{HASHES.NGINX_AUTH_PROXY_COMMIT_HASH}"
+            },
+            {
+              name  = "UI_IMAGE_HASH"
+              value = "#{HASHES.UI_IMAGE_HASH}"
             }
           ]
         )
@@ -522,6 +554,10 @@ resource "aws_codepipeline" "path_to_live" {
             {
               name  = "NGINX_AUTH_PROXY_IMAGE_HASH"
               value = "#{HASHES.NGINX_AUTH_PROXY_IMAGE_HASH}"
+            },
+            {
+              name  = "UI_IMAGE_HASH"
+              value = "#{HASHES.UI_IMAGE_HASH}"
             }
           ]
         )
@@ -560,6 +596,10 @@ resource "aws_codepipeline" "path_to_live" {
             {
               name  = "TF_VAR_nginx_auth_proxy_deploy_tag"
               value = "#{HASHES.NGINX_AUTH_PROXY_IMAGE_HASH}"
+            },
+            {
+              name  = "TF_VAR_ui_deploy_tag"
+              value = "#{HASHES.UI_IMAGE_HASH}"
             }
           ]
         )
@@ -666,7 +706,11 @@ module "update_environment_ssm_params" {
     {
       name  = "NGINX_AUTH_PROXY_REPO"
       value = module.codebuild_docker_resources.nginx_auth_proxy.name
-    }
+    },
+    {
+      name  = "UI_REPO"
+      value = module.codebuild_docker_resources.ui_repository.name
+    },
   ]
 
   tags = module.label.tags

--- a/terraform/shared_account_sandbox_infra_ci/main.tf
+++ b/terraform/shared_account_sandbox_infra_ci/main.tf
@@ -65,6 +65,8 @@ module "common_build_jobs" {
   reporting_cd_env_vars     = local.bichard_cd_vars
   scanning_results_bucket   = module.codebuild_base_resources.scanning_results_bucket
   common_cd_vars            = local.common_cd_vars
+  ui_cd_env_vars            = local.bichard_cd_vars
+  core_cd_env_vars          = local.bichard_cd_vars
 
   tags = module.label.tags
 }


### PR DESCRIPTION
- codebuild job to build the ui docker image watches github for pushes to main and builds the semaphore
- watch for semaphore changes and trigger a pipeline release on change
- pass the ui image hash through the pipeline line so can be picked up by "code to be deployed" slack bot

- Refactor core codebuild job to run as container (code was copied from the reporting codebuild job)

Will only merge once the ecr repo is already deployed to prod