### PR TITLE
feat: 🎸 add slack lambda & ecr alarm when no images in repo

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci_monitoring/README.md
+++ b/terraform/shared_account_pathtolive_infra_ci_monitoring/README.md
@@ -15,6 +15,7 @@ Creates a Grafana ECS cluster that pulls metrics from Cloudwatch
 
 | Name | Version |
 |------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.2.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.2.2 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
@@ -25,12 +26,22 @@ Creates a Grafana ECS cluster that pulls metrics from Cloudwatch
 |------|--------|---------|
 | <a name="module_codebuild_monitoring"></a> [codebuild\_monitoring](#module\_codebuild\_monitoring) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_monitoring | n/a |
 | <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_lambda_slack_webhook"></a> [lambda\_slack\_webhook](#module\_lambda\_slack\_webhook) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_slack_webhook | n/a |
 | <a name="module_tag_vars"></a> [tag\_vars](#module\_tag\_vars) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_event_rule.query_ecr_images_cron_schedule](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.query_ecr_images_every_hour](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_metric_alarm.query_ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_iam_policy.lambda_allow_to_list_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.lambda_num_of_repos_manage_ec2_network_interfaces](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
+| [aws_iam_role.ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role) | resource |
+| [aws_lambda_function.query_images_fn](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.allow_cloudwatch_to_invoke_query_ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission) | resource |
+| [archive_file.query_num_of_repo_images](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
 | [aws_ecr_repository.grafana_codebuild](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository) | data source |
 | [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |

--- a/terraform/shared_account_pathtolive_infra_ci_monitoring/README.md
+++ b/terraform/shared_account_pathtolive_infra_ci_monitoring/README.md
@@ -3,51 +3,52 @@
 Creates a Grafana ECS cluster that pulls metrics from Cloudwatch
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | = 2.0.0 |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
+| <a name="requirement_local"></a> [local](#requirement_local)             | = 2.0.0  |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.2.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.2.2 |
-| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+| Name                                                               | Version |
+| ------------------------------------------------------------------ | ------- |
+| <a name="provider_archive"></a> [archive](#provider_archive)       | 2.2.0   |
+| <a name="provider_aws"></a> [aws](#provider_aws)                   | 3.75.2  |
+| <a name="provider_external"></a> [external](#provider_external)    | 2.2.2   |
+| <a name="provider_terraform"></a> [terraform](#provider_terraform) | n/a     |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_codebuild_monitoring"></a> [codebuild\_monitoring](#module\_codebuild\_monitoring) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_monitoring | n/a |
-| <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_lambda_slack_webhook"></a> [lambda\_slack\_webhook](#module\_lambda\_slack\_webhook) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_slack_webhook | n/a |
-| <a name="module_tag_vars"></a> [tag\_vars](#module\_tag\_vars) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars | n/a |
+| Name                                                                                            | Source                                                                                              | Version |
+| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------- |
+| <a name="module_codebuild_monitoring"></a> [codebuild_monitoring](#module_codebuild_monitoring) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_monitoring | n/a     |
+| <a name="module_label"></a> [label](#module_label)                                              | cloudposse/label/null                                                                               | 0.24.1  |
+| <a name="module_lambda_slack_webhook"></a> [lambda_slack_webhook](#module_lambda_slack_webhook) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_slack_webhook | n/a     |
+| <a name="module_tag_vars"></a> [tag_vars](#module_tag_vars)                                     | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars             | n/a     |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_cloudwatch_event_rule.query_ecr_images_cron_schedule](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_target.query_ecr_images_every_hour](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_target) | resource |
-| [aws_cloudwatch_metric_alarm.query_ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm) | resource |
-| [aws_iam_policy.lambda_allow_to_list_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.lambda_num_of_repos_manage_ec2_network_interfaces](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
-| [aws_iam_role.ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role) | resource |
-| [aws_lambda_function.query_images_fn](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function) | resource |
-| [aws_lambda_permission.allow_cloudwatch_to_invoke_query_ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission) | resource |
-| [archive_file.query_num_of_repo_images](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_ecr_repository.grafana_codebuild](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository) | data source |
-| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
-| [external_external.latest_grafana_codebuild_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
-| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.shared_infra_ci](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| Name                                                                                                                                                             | Type        |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_cloudwatch_event_rule.query_ecr_images_cron_schedule](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_rule)    | resource    |
+| [aws_cloudwatch_event_target.query_ecr_images_every_hour](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_target)   | resource    |
+| [aws_cloudwatch_metric_alarm.query_ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm)         | resource    |
+| [aws_iam_policy.lambda_allow_to_list_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)                             | resource    |
+| [aws_iam_policy.lambda_num_of_repos_manage_ec2_network_interfaces](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)       | resource    |
+| [aws_iam_role.ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role)                                             | resource    |
+| [aws_lambda_function.query_images_fn](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function)                               | resource    |
+| [aws_lambda_permission.allow_cloudwatch_to_invoke_query_ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission) | resource    |
+| [archive_file.query_num_of_repo_images](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file)                                 | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                    | data source |
+| [aws_ecr_repository.grafana_codebuild](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository)                            | data source |
+| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                               | data source |
+| [external_external.latest_grafana_codebuild_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external)                 | data source |
+| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state)                         | data source |
+| [terraform_remote_state.shared_infra_ci](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state)                      | data source |
 
 ## Inputs
 
@@ -55,7 +56,8 @@ No inputs.
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_grafana_url"></a> [grafana\_url](#output\_grafana\_url) | The url of our grafana server |
+| Name                                                                 | Description                   |
+| -------------------------------------------------------------------- | ----------------------------- |
+| <a name="output_grafana_url"></a> [grafana_url](#output_grafana_url) | The url of our grafana server |
+
 <!-- END_TF_DOCS -->

--- a/terraform/shared_account_pathtolive_infra_ci_monitoring/data.tf
+++ b/terraform/shared_account_pathtolive_infra_ci_monitoring/data.tf
@@ -36,3 +36,19 @@ data "external" "latest_grafana_codebuild_image" {
     "--query", "{\"tags\": to_string(sort_by(imageDetails,& imagePushedAt)[-1].imageDigest)}",
   ]
 }
+
+data "archive_file" "query_num_of_repo_images" {
+  output_path = "/tmp/query_long_running_fns.zip"
+  type        = "zip"
+
+  source {
+    content = templatefile("${path.module}/source/query_num_of_repo_images.py.tpl", {
+      region     = data.aws_region.current_region.name
+      account_id = data.aws_caller_identity.current.account_id
+      env        = terraform.workspace
+    })
+    filename = "query_long_running_fns.py"
+  }
+}
+
+// data sns topic for slack webhook

--- a/terraform/shared_account_pathtolive_infra_ci_monitoring/ecr_alarms.tf
+++ b/terraform/shared_account_pathtolive_infra_ci_monitoring/ecr_alarms.tf
@@ -1,0 +1,127 @@
+# tfsec:ignore:aws-iam-no-policy-wildcards
+resource "aws_iam_policy" "lambda_num_of_repos_manage_ec2_network_interfaces" {
+  name = "bichard-7-${terraform.workspace}-num-of-repos-lambda-manage-ec2-network-interfaces"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:AttachNetworkInterface",
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeInstances",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = module.label.tags
+}
+
+# tfsec:ignore:aws-iam-no-policy-wildcards
+resource "aws_iam_policy" "lambda_allow_to_list_images" {
+  name = "bichard-7-${terraform.workspace}-list-images"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:ListImages",
+        ]
+        Resource = [
+          "*"
+        ]
+      }
+    ]
+  })
+
+  tags = module.label.tags
+}
+
+
+resource "aws_iam_role" "ecr_repo_images" {
+  name               = "bichard-7-${terraform.workspace}-allow-query-long-running-fns"
+  assume_role_policy = file("${path.module}/policies/allow_lambda_query.json")
+
+  managed_policy_arns = [aws_iam_policy.lambda_num_of_repos_manage_ec2_network_interfaces.arn, aws_iam_policy.lambda_allow_to_list_images.arn, "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
+  tags                = module.label.tags
+}
+
+# tfsec:ignore:aws-lambda-enable-tracing
+resource "aws_lambda_function" "query_images_fn" {
+  function_name = "${terraform.workspace}-query-ecr-images"
+  description   = "Query the number of images in an ecr repo"
+
+  filename         = data.archive_file.query_num_of_repo_images.output_path
+  source_code_hash = data.archive_file.query_num_of_repo_images.output_base64sha256
+  handler          = "query_number_of_repo_images.lambda_handler"
+
+  vpc_config {
+    subnet_ids         = data.terraform_remote_state.shared_infra_ci.outputs.codebuild_subnet_ids
+    security_group_ids = []
+  }
+
+  role        = aws_iam_role.ecr_repo_images
+  memory_size = "128"
+  runtime     = "python3.8"
+  timeout     = "5"
+
+  tags = module.label.tags
+}
+
+resource "aws_cloudwatch_event_rule" "query_ecr_images_cron_schedule" {
+  name                = "query-ecr-images-cron-schedule"
+  description         = "Fires every hour"
+  schedule_expression = "cron(00 * * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "query_ecr_images_every_hour" {
+  rule      = aws_cloudwatch_event_rule.query_ecr_images_cron_schedule.name
+  target_id = "lambda"
+  arn       = aws_lambda_function.query_images_fn.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_invoke_query_ecr_repo" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.query_images_fn.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.query_ecr_images_cron_schedule.arn
+}
+
+resource "aws_cloudwatch_metric_alarm" "query_ecr_repo_images" {
+  alarm_name        = "Query number of images in repo under threshold for ${terraform.workspace}"
+  alarm_description = "There no images in ${terraform.workspace}, check the 'query-ecr-images' lambda logs for more details"
+
+  evaluation_periods  = 5
+  datapoints_to_alarm = 1
+  period              = 60
+  threshold           = 1
+  treat_missing_data  = "ignore"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+
+  alarm_actions = [
+    module.lambda_slack_webhook.slack_sns_topic[0].arn
+  ]
+  ok_actions = [
+    module.lambda_slack_webhook.slack_sns_topic[0].arn
+  ]
+
+  actions_enabled = true
+
+  dimensions = {
+    FunctionName = aws_lambda_function.query_images_fn.function_name
+  }
+  tags = module.label.tags
+}

--- a/terraform/shared_account_pathtolive_infra_ci_monitoring/lambda_slack_webhook.tf
+++ b/terraform/shared_account_pathtolive_infra_ci_monitoring/lambda_slack_webhook.tf
@@ -1,0 +1,7 @@
+module "lambda_slack_webhook" {
+  source = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_slack_webhook"
+
+  name = "${terraform.workspace}-bichard-7"
+
+  tags = module.label.tags
+}

--- a/terraform/shared_account_pathtolive_infra_ci_monitoring/policies/allow_lambda_query.json
+++ b/terraform/shared_account_pathtolive_infra_ci_monitoring/policies/allow_lambda_query.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}

--- a/terraform/shared_account_pathtolive_infra_ci_monitoring/source/query_num_of_repo_images.py.tpl
+++ b/terraform/shared_account_pathtolive_infra_ci_monitoring/source/query_num_of_repo_images.py.tpl
@@ -1,0 +1,41 @@
+# periodically (every hour) get the number of images in each ecr repo
+
+import boto3
+
+client = boto3.client('ecr')
+
+def recurisive_paginate_images(repo, image_array, next_token=''):
+    repsonse = {}
+    if next_token == '':
+        response = client.list_images(
+            repositoryName=repo,
+            registryId="497078235711"
+        )
+    else:
+        response = client.list_images(
+            repositoryName=repo,
+            registryId="497078235711",
+            nextToken=next_token
+        )
+
+    if "nextToken" in response:
+        recurisive_paginate_images(repo, image_array +
+                            response["imageIds"], response["nextToken"])
+
+    return image_array + response["imageIds"]
+
+def get_repos():
+    response = client.describe_repositories(
+                registryId="497078235711"
+            )
+
+    return [repo["repositoryName"] for repo in response["repositories"]]
+
+def lambda_handler(event, context):
+    repo_names = get_repos()
+    for repo in repo_names:
+        images = recurisive_paginate_images(repo, [])
+
+        if len(images) == 0:
+            raise Exception(
+                "There are no images in the: "+repo+" repository")

--- a/terraform/shared_account_pathtolive_infra_ci_monitoring/source/query_num_of_repo_images.py.tpl
+++ b/terraform/shared_account_pathtolive_infra_ci_monitoring/source/query_num_of_repo_images.py.tpl
@@ -4,6 +4,7 @@ import boto3
 
 client = boto3.client('ecr')
 
+
 def recurisive_paginate_images(repo, image_array, next_token=''):
     repsonse = {}
     if next_token == '':
@@ -20,16 +21,18 @@ def recurisive_paginate_images(repo, image_array, next_token=''):
 
     if "nextToken" in response:
         recurisive_paginate_images(repo, image_array +
-                            response["imageIds"], response["nextToken"])
+                                   response["imageIds"], response["nextToken"])
 
     return image_array + response["imageIds"]
 
+
 def get_repos():
     response = client.describe_repositories(
-                registryId="497078235711"
-            )
+        registryId="497078235711"
+    )
 
     return [repo["repositoryName"] for repo in response["repositories"]]
+
 
 def lambda_handler(event, context):
     repo_names = get_repos()


### PR DESCRIPTION
This creates:

- a new slack lambda in the parent ptl account
- cloudwatch alarm that triggers if there are no image in the ecr repo

I went with this method as it was simplier than the keeping all the alarms in the child account, doing that would mean fiddling around with lots of cross account permissions for each repo and for the cloudwatch alarm lambda too.