### PR TITLE
fix: 🐛 ui was not updating semaphores; didn't have cd env vars

### DIFF
--- a/terraform/modules/shared_cd_common_jobs/build_ui.tf
+++ b/terraform/modules/shared_cd_common_jobs/build_ui.tf
@@ -8,12 +8,7 @@ module "build_bichard7_ui_docker_image" {
   name                   = "build-ui-docker"
   repository_name        = "bichard7-next-ui"
 
-  environment_variables = [
-    {
-      name  = "ARTIFACT_BUCKET"
-      value = var.codebuild_s3_bucket
-    }
-  ]
+  environment_variables = var.ui_cd_env_vars
 
   tags = var.tags
 }

--- a/terraform/modules/shared_cd_common_jobs/outputs.tf
+++ b/terraform/modules/shared_cd_common_jobs/outputs.tf
@@ -18,6 +18,16 @@ output "build_user_service_service_role_name" {
   value       = module.build_bichard7_user_service_docker_image.pipeline_service_role_name
 }
 
+output "build_ui_name" {
+  description = "The name of our ui docker image build job"
+  value       = module.build_bichard7_ui_docker_image.pipeline_name
+}
+
+output "build_ui_service_role_name" {
+  description = "The name of our build ui job service role"
+  value       = module.build_bichard7_ui_docker_image.pipeline_service_role_name
+}
+
 output "build_audit_logging_name" {
   description = "The name of our audit logging docker image build job"
   value       = module.build_audit_logging.pipeline_name

--- a/terraform/shared_account_pathtolive_infra_ci/main.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/main.tf
@@ -57,6 +57,7 @@ module "common_build_jobs" {
   bichard_cd_env_vars       = local.bichard_cd_vars
   audit_logging_cd_env_vars = local.bichard_cd_vars
   user_service_cd_env_vars  = local.bichard_cd_vars
+  ui_cd_env_vars            = local.bichard_cd_vars
   beanconnect_cd_env_vars   = local.bichard_cd_vars
   reporting_cd_env_vars     = local.bichard_cd_vars
   common_cd_vars            = local.common_cd_vars


### PR DESCRIPTION
ui hash wasn't updating because the correct env vars weren't being passed to it when the image was being built, this passes the IS_CD env vars to the ui codebuild job so will now update the semaphores.