### PR TITLE
Delete sandbox b nuke resources temporarily

### DIFF
--- a/terraform/shared_account_sandbox_infra_ci/locals.tf
+++ b/terraform/shared_account_sandbox_infra_ci/locals.tf
@@ -12,10 +12,10 @@ locals {
       id     = data.aws_caller_identity.sandbox_a.account_id
       target = "sandbox-a"
     },
-    {
-      id     = data.aws_caller_identity.sandbox_b.account_id
-      target = "sandbox-b"
-    },
+    # {
+    #   id     = data.aws_caller_identity.sandbox_b.account_id
+    #   target = "sandbox-b"
+    # },
     {
       id     = data.aws_caller_identity.sandbox_c.account_id
       target = "sandbox-c"


### PR DESCRIPTION
Delete sandbox b nuke temporarily to avoid deletion of resources deployed to sandbox b.