### PR TITLE
Revert "Delete sandbox b nuke resources temporarily (#87)"

### DIFF
--- a/terraform/shared_account_sandbox_infra_ci/locals.tf
+++ b/terraform/shared_account_sandbox_infra_ci/locals.tf
@@ -12,10 +12,10 @@ locals {
       id     = data.aws_caller_identity.sandbox_a.account_id
       target = "sandbox-a"
     },
-    # {
-    #   id     = data.aws_caller_identity.sandbox_b.account_id
-    #   target = "sandbox-b"
-    # },
+    {
+      id     = data.aws_caller_identity.sandbox_b.account_id
+      target = "sandbox-b"
+    },
     {
       id     = data.aws_caller_identity.sandbox_c.account_id
       target = "sandbox-c"


### PR DESCRIPTION
This PR re enables the Sandbox B nuke codebuild job.
This reverts commit c38951032d6eb996362a456579afc01132788cb3.