### PR TITLE
ci: 🎡 import infra modules param to code build deploy steps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0  # Use the ref you want to point at
+    rev: v4.3.0 # Use the ref you want to point at
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: detect-private-key
       - id: pretty-format-json
         args:
-          - '--no-sort-keys'
+          - "--no-sort-keys"
       - id: mixed-line-ending
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
@@ -42,7 +42,7 @@ repos:
         name: terraform-docs
         language: docker_image
         entry: quay.io/terraform-docs/terraform-docs:0.16.0
-        args: [ "markdown", "--recursive", "--recursive-path", ".", "--output-file", "README.md", "./terraform" ]
+        args: ["markdown", "--recursive", "--recursive-path", ".", "--output-file", "README.md", "./terraform"]
         pass_filenames: false
 
   - repo: https://github.com/ansible/ansible-lint.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,6 @@ repos:
     rev: v4.3.0  # Use the ref you want to point at
     hooks:
       - id: trailing-whitespace
-      - id: detect-aws-credentials
-        args:
-          - "--allow-missing-credentials"
       - id: end-of-file-fixer
       - id: detect-private-key
       - id: pretty-format-json

--- a/terraform/shared_account_pathtolive_infra/README.md
+++ b/terraform/shared_account_pathtolive_infra/README.md
@@ -24,104 +24,102 @@ a `qsolutions-auth` profile set up in Aws-Vault. You will also need `jq` install
 For the delegated hosted zone parent see [this readme](../shared_account_sandbox_infra/README.md)
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version  |
-| ------------------------------------------------------------------------ | -------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
-| <a name="requirement_local"></a> [local](#requirement_local)             | ~> 2.0.0 |
-| <a name="requirement_null"></a> [null](#requirement_null)                | ~> 3.0.0 |
-| <a name="requirement_template"></a> [template](#requirement_template)    | ~> 2.2.0 |
-| <a name="requirement_tls"></a> [tls](#requirement_tls)                   | ~> 3.1.0 |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0.0 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | ~> 2.2.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.1.0 |
 
 ## Providers
 
-| Name                                                                                                            | Version  |
-| --------------------------------------------------------------------------------------------------------------- | -------- |
-| <a name="provider_aws"></a> [aws](#provider_aws)                                                                | = 3.75.2 |
-| <a name="provider_aws.integration_baseline"></a> [aws.integration_baseline](#provider_aws.integration_baseline) | = 3.75.2 |
-| <a name="provider_aws.integration_next"></a> [aws.integration_next](#provider_aws.integration_next)             | = 3.75.2 |
-| <a name="provider_aws.preprod"></a> [aws.preprod](#provider_aws.preprod)                                        | = 3.75.2 |
-| <a name="provider_aws.production"></a> [aws.production](#provider_aws.production)                               | = 3.75.2 |
-| <a name="provider_aws.sandbox"></a> [aws.sandbox](#provider_aws.sandbox)                                        | = 3.75.2 |
-| <a name="provider_aws.shared"></a> [aws.shared](#provider_aws.shared)                                           | = 3.75.2 |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
+| <a name="provider_aws.integration_baseline"></a> [aws.integration\_baseline](#provider\_aws.integration\_baseline) | 3.75.2 |
+| <a name="provider_aws.integration_next"></a> [aws.integration\_next](#provider\_aws.integration\_next) | 3.75.2 |
+| <a name="provider_aws.preprod"></a> [aws.preprod](#provider\_aws.preprod) | 3.75.2 |
+| <a name="provider_aws.production"></a> [aws.production](#provider\_aws.production) | 3.75.2 |
+| <a name="provider_aws.sandbox"></a> [aws.sandbox](#provider\_aws.sandbox) | 3.75.2 |
+| <a name="provider_aws.shared"></a> [aws.shared](#provider\_aws.shared) | 3.75.2 |
 
 ## Modules
 
-| Name                                                                                                                                                                                                                    | Source                                                                                                      | Version   |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | --------- |
-| <a name="module_aws_logs"></a> [aws_logs](#module_aws_logs)                                                                                                                                                             | trussworks/logs/aws                                                                                         | ~> 10.3.0 |
-| <a name="module_integration_baseline_child_access"></a> [integration_baseline_child_access](#module_integration_baseline_child_access)                                                                                  | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
-| <a name="module_integration_next_child_access"></a> [integration_next_child_access](#module_integration_next_child_access)                                                                                              | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
-| <a name="module_label"></a> [label](#module_label)                                                                                                                                                                      | cloudposse/label/null                                                                                       | 0.24.1    |
-| <a name="module_preprod_child_access"></a> [preprod_child_access](#module_preprod_child_access)                                                                                                                         | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
-| <a name="module_production_child_access"></a> [production_child_access](#module_production_child_access)                                                                                                                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
-| <a name="module_shared_account_access_integration_baseline"></a> [shared_account_access_integration_baseline](#module_shared_account_access_integration_baseline)                                                       | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
-| <a name="module_shared_account_access_integration_baseline_lambda_cloudtrail"></a> [shared_account_access_integration_baseline_lambda_cloudtrail](#module_shared_account_access_integration_baseline_lambda_cloudtrail) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail            | n/a       |
-| <a name="module_shared_account_access_integration_next"></a> [shared_account_access_integration_next](#module_shared_account_access_integration_next)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
-| <a name="module_shared_account_access_integration_next_lambda_cloudtrail"></a> [shared_account_access_integration_next_lambda_cloudtrail](#module_shared_account_access_integration_next_lambda_cloudtrail)             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail            | n/a       |
-| <a name="module_shared_account_access_preprod"></a> [shared_account_access_preprod](#module_shared_account_access_preprod)                                                                                              | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
-| <a name="module_shared_account_access_production"></a> [shared_account_access_production](#module_shared_account_access_production)                                                                                     | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
-| <a name="module_shared_account_preprod_lambda_cloudtrail"></a> [shared_account_preprod_lambda_cloudtrail](#module_shared_account_preprod_lambda_cloudtrail)                                                             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail            | n/a       |
-| <a name="module_shared_account_production_next_lambda_cloudtrail"></a> [shared_account_production_next_lambda_cloudtrail](#module_shared_account_production_next_lambda_cloudtrail)                                     | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail            | n/a       |
-| <a name="module_shared_account_user_access"></a> [shared_account_user_access](#module_shared_account_user_access)                                                                                                       | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent        | n/a       |
-| <a name="module_tag_vars"></a> [tag_vars](#module_tag_vars)                                                                                                                                                             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars                     | n/a       |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aws_logs"></a> [aws\_logs](#module\_aws\_logs) | trussworks/logs/aws | ~> 10.3.0  |
+| <a name="module_integration_baseline_child_access"></a> [integration\_baseline\_child\_access](#module\_integration\_baseline\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
+| <a name="module_integration_next_child_access"></a> [integration\_next\_child\_access](#module\_integration\_next\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
+| <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_preprod_child_access"></a> [preprod\_child\_access](#module\_preprod\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
+| <a name="module_production_child_access"></a> [production\_child\_access](#module\_production\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
+| <a name="module_shared_account_access_integration_baseline"></a> [shared\_account\_access\_integration\_baseline](#module\_shared\_account\_access\_integration\_baseline) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
+| <a name="module_shared_account_access_integration_baseline_lambda_cloudtrail"></a> [shared\_account\_access\_integration\_baseline\_lambda\_cloudtrail](#module\_shared\_account\_access\_integration\_baseline\_lambda\_cloudtrail) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail | n/a |
+| <a name="module_shared_account_access_integration_next"></a> [shared\_account\_access\_integration\_next](#module\_shared\_account\_access\_integration\_next) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
+| <a name="module_shared_account_access_integration_next_lambda_cloudtrail"></a> [shared\_account\_access\_integration\_next\_lambda\_cloudtrail](#module\_shared\_account\_access\_integration\_next\_lambda\_cloudtrail) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail | n/a |
+| <a name="module_shared_account_access_preprod"></a> [shared\_account\_access\_preprod](#module\_shared\_account\_access\_preprod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
+| <a name="module_shared_account_access_production"></a> [shared\_account\_access\_production](#module\_shared\_account\_access\_production) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
+| <a name="module_shared_account_preprod_lambda_cloudtrail"></a> [shared\_account\_preprod\_lambda\_cloudtrail](#module\_shared\_account\_preprod\_lambda\_cloudtrail) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail | n/a |
+| <a name="module_shared_account_production_next_lambda_cloudtrail"></a> [shared\_account\_production\_next\_lambda\_cloudtrail](#module\_shared\_account\_production\_next\_lambda\_cloudtrail) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail | n/a |
+| <a name="module_shared_account_user_access"></a> [shared\_account\_user\_access](#module\_shared\_account\_user\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent | n/a |
+| <a name="module_tag_vars"></a> [tag\_vars](#module\_tag\_vars) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars | n/a |
 
 ## Resources
 
-| Name                                                                                                                                              | Type        |
-| ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [aws_route53_record.bichard7_pathtolive_name_servers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource    |
-| [aws_route53_zone.bichard7_pathtolive_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone)   | resource    |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                     | data source |
-| [aws_caller_identity.integration_baseline](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)        | data source |
-| [aws_caller_identity.integration_next](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)            | data source |
-| [aws_caller_identity.preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                     | data source |
-| [aws_caller_identity.production](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                  | data source |
-| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                | data source |
-| [aws_ssm_parameter.non_sc_users](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter)                    | data source |
+| Name | Type |
+|------|------|
+| [aws_route53_record.bichard7_pathtolive_name_servers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
+| [aws_route53_zone.bichard7_pathtolive_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.integration_baseline](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.integration_next](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.production](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
+| [aws_ssm_parameter.non_sc_users](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
 
-| Name                                                                                                                           | Description                                         | Type     | Default                   | Required |
-| ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- | -------- | ------------------------- | :------: |
-| <a name="input_integration_baseline_access_key"></a> [integration_baseline_access_key](#input_integration_baseline_access_key) | the AWS_ACCESS_KEY_ID for integration_baseline      | `string` | n/a                       |   yes    |
-| <a name="input_integration_baseline_secret_key"></a> [integration_baseline_secret_key](#input_integration_baseline_secret_key) | the AWS_SECRET_ACCESS_KEY for integration_baseline  | `string` | n/a                       |   yes    |
-| <a name="input_integration_next_access_key"></a> [integration_next_access_key](#input_integration_next_access_key)             | the AWS_ACCESS_KEY_ID for integration_next          | `string` | n/a                       |   yes    |
-| <a name="input_integration_next_secret_key"></a> [integration_next_secret_key](#input_integration_next_secret_key)             | the AWS_SECRET_ACCESS_KEY for integration_next      | `string` | n/a                       |   yes    |
-| <a name="input_parent_zone_id"></a> [parent_zone_id](#input_parent_zone_id)                                                    | The zone id of our parent hosted zone               | `string` | `"Z0532960253T16WMNSRNR"` |    no    |
-| <a name="input_preprod_access_key"></a> [preprod_access_key](#input_preprod_access_key)                                        | the AWS_ACCESS_KEY_ID for Q Solution preprod        | `string` | n/a                       |   yes    |
-| <a name="input_preprod_secret_key"></a> [preprod_secret_key](#input_preprod_secret_key)                                        | the AWS_SECRET_ACCESS_KEY for Q Solution preprod    | `string` | n/a                       |   yes    |
-| <a name="input_preprod_session_token"></a> [preprod_session_token](#input_preprod_session_token)                               | the AWS_SESSION_TOKEN for Q Solution preprod        | `string` | n/a                       |   yes    |
-| <a name="input_production_access_key"></a> [production_access_key](#input_production_access_key)                               | the AWS_ACCESS_KEY_ID for Q Solution production     | `string` | n/a                       |   yes    |
-| <a name="input_production_secret_key"></a> [production_secret_key](#input_production_secret_key)                               | the AWS_SECRET_ACCESS_KEY for Q Solution production | `string` | n/a                       |   yes    |
-| <a name="input_production_session_token"></a> [production_session_token](#input_production_session_token)                      | the AWS_SESSION_TOKEN for Q Solution production     | `string` | n/a                       |   yes    |
-| <a name="input_region"></a> [region](#input_region)                                                                            | The AWS region                                      | `string` | `"eu-west-2"`             |    no    |
-| <a name="input_slack_webhook"></a> [slack_webhook](#input_slack_webhook)                                                       | Our webhook for sending messages to slack           | `string` | `""`                      |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_integration_baseline_access_key"></a> [integration\_baseline\_access\_key](#input\_integration\_baseline\_access\_key) | the AWS\_ACCESS\_KEY\_ID for integration\_baseline | `string` | n/a | yes |
+| <a name="input_integration_baseline_secret_key"></a> [integration\_baseline\_secret\_key](#input\_integration\_baseline\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for integration\_baseline | `string` | n/a | yes |
+| <a name="input_integration_next_access_key"></a> [integration\_next\_access\_key](#input\_integration\_next\_access\_key) | the AWS\_ACCESS\_KEY\_ID for integration\_next | `string` | n/a | yes |
+| <a name="input_integration_next_secret_key"></a> [integration\_next\_secret\_key](#input\_integration\_next\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for integration\_next | `string` | n/a | yes |
+| <a name="input_parent_zone_id"></a> [parent\_zone\_id](#input\_parent\_zone\_id) | The zone id of our parent hosted zone | `string` | `"Z0532960253T16WMNSRNR"` | no |
+| <a name="input_preprod_access_key"></a> [preprod\_access\_key](#input\_preprod\_access\_key) | the AWS\_ACCESS\_KEY\_ID for Q Solution preprod | `string` | n/a | yes |
+| <a name="input_preprod_secret_key"></a> [preprod\_secret\_key](#input\_preprod\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for Q Solution preprod | `string` | n/a | yes |
+| <a name="input_preprod_session_token"></a> [preprod\_session\_token](#input\_preprod\_session\_token) | the AWS\_SESSION\_TOKEN for Q Solution preprod | `string` | n/a | yes |
+| <a name="input_production_access_key"></a> [production\_access\_key](#input\_production\_access\_key) | the AWS\_ACCESS\_KEY\_ID for Q Solution production | `string` | n/a | yes |
+| <a name="input_production_secret_key"></a> [production\_secret\_key](#input\_production\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for Q Solution production | `string` | n/a | yes |
+| <a name="input_production_session_token"></a> [production\_session\_token](#input\_production\_session\_token) | the AWS\_SESSION\_TOKEN for Q Solution production | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region | `string` | `"eu-west-2"` | no |
+| <a name="input_slack_webhook"></a> [slack\_webhook](#input\_slack\_webhook) | Our webhook for sending messages to slack | `string` | `""` | no |
 
 ## Outputs
 
-| Name                                                                                                                                   | Description                                             |
-| -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| <a name="output_admin_group_name"></a> [admin_group_name](#output_admin_group_name)                                                    | The name of our admin group                             |
-| <a name="output_ci_group_name"></a> [ci_group_name](#output_ci_group_name)                                                             | The name of our ci group                                |
-| <a name="output_ci_users"></a> [ci_users](#output_ci_users)                                                                            | A list of our CI users                                  |
-| <a name="output_delegated_hosted_zone"></a> [delegated_hosted_zone](#output_delegated_hosted_zone)                                     | Our pathtolive hosted zone                              |
-| <a name="output_integration_baseline_admin_arn"></a> [integration_baseline_admin_arn](#output_integration_baseline_admin_arn)          | The integration_baseline Admin Assume Role ARN          |
-| <a name="output_integration_baseline_ci_arn"></a> [integration_baseline_ci_arn](#output_integration_baseline_ci_arn)                   | The integration_baseline CI Assume Role ARN             |
-| <a name="output_integration_baseline_readonly_arn"></a> [integration_baseline_readonly_arn](#output_integration_baseline_readonly_arn) | The integration_baseline ReadOnly Assume Role ARN       |
-| <a name="output_integration_next_admin_arn"></a> [integration_next_admin_arn](#output_integration_next_admin_arn)                      | The integration_next Admin Assume Role ARN              |
-| <a name="output_integration_next_ci_arn"></a> [integration_next_ci_arn](#output_integration_next_ci_arn)                               | The integration_next CI Assume Role ARN                 |
-| <a name="output_integration_next_readonly_arn"></a> [integration_next_readonly_arn](#output_integration_next_readonly_arn)             | The integration_next ReadOnly Assume Role ARN           |
-| <a name="output_mfa_group_name"></a> [mfa_group_name](#output_mfa_group_name)                                                          | The name of our MFA group                               |
-| <a name="output_preprod_admin_arn"></a> [preprod_admin_arn](#output_preprod_admin_arn)                                                 | The preprod Admin Assume Role ARN                       |
-| <a name="output_preprod_ci_arn"></a> [preprod_ci_arn](#output_preprod_ci_arn)                                                          | The preprod CI Assume Role ARN                          |
-| <a name="output_production_admin_arn"></a> [production_admin_arn](#output_production_admin_arn)                                        | The production Admin Assume Role ARN                    |
-| <a name="output_production_ci_arn"></a> [production_ci_arn](#output_production_ci_arn)                                                 | The production CI Assume Role ARN                       |
-| <a name="output_readonly_group_name"></a> [readonly_group_name](#output_readonly_group_name)                                           | The name of our readonly group                          |
-| <a name="output_s3_logging_bucket_name"></a> [s3_logging_bucket_name](#output_s3_logging_bucket_name)                                  | The name of our shared logging bucket                   |
-| <a name="output_shared_ci_policy_arn"></a> [shared_ci_policy_arn](#output_shared_ci_policy_arn)                                        | The arn of our ci policy consumed by our codebuild jobs |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_admin_group_name"></a> [admin\_group\_name](#output\_admin\_group\_name) | The name of our admin group |
+| <a name="output_ci_group_name"></a> [ci\_group\_name](#output\_ci\_group\_name) | The name of our ci group |
+| <a name="output_ci_users"></a> [ci\_users](#output\_ci\_users) | A list of our CI users |
+| <a name="output_delegated_hosted_zone"></a> [delegated\_hosted\_zone](#output\_delegated\_hosted\_zone) | Our pathtolive hosted zone |
+| <a name="output_integration_baseline_admin_arn"></a> [integration\_baseline\_admin\_arn](#output\_integration\_baseline\_admin\_arn) | The integration\_baseline Admin Assume Role ARN |
+| <a name="output_integration_baseline_ci_arn"></a> [integration\_baseline\_ci\_arn](#output\_integration\_baseline\_ci\_arn) | The integration\_baseline CI Assume Role ARN |
+| <a name="output_integration_baseline_readonly_arn"></a> [integration\_baseline\_readonly\_arn](#output\_integration\_baseline\_readonly\_arn) | The integration\_baseline ReadOnly Assume Role ARN |
+| <a name="output_integration_next_admin_arn"></a> [integration\_next\_admin\_arn](#output\_integration\_next\_admin\_arn) | The integration\_next Admin Assume Role ARN |
+| <a name="output_integration_next_ci_arn"></a> [integration\_next\_ci\_arn](#output\_integration\_next\_ci\_arn) | The integration\_next CI Assume Role ARN |
+| <a name="output_integration_next_readonly_arn"></a> [integration\_next\_readonly\_arn](#output\_integration\_next\_readonly\_arn) | The integration\_next ReadOnly Assume Role ARN |
+| <a name="output_mfa_group_name"></a> [mfa\_group\_name](#output\_mfa\_group\_name) | The name of our MFA group |
+| <a name="output_preprod_admin_arn"></a> [preprod\_admin\_arn](#output\_preprod\_admin\_arn) | The preprod Admin Assume Role ARN |
+| <a name="output_preprod_ci_arn"></a> [preprod\_ci\_arn](#output\_preprod\_ci\_arn) | The preprod CI Assume Role ARN |
+| <a name="output_production_admin_arn"></a> [production\_admin\_arn](#output\_production\_admin\_arn) | The production Admin Assume Role ARN |
+| <a name="output_production_ci_arn"></a> [production\_ci\_arn](#output\_production\_ci\_arn) | The production CI Assume Role ARN |
+| <a name="output_readonly_group_name"></a> [readonly\_group\_name](#output\_readonly\_group\_name) | The name of our readonly group |
+| <a name="output_s3_logging_bucket_name"></a> [s3\_logging\_bucket\_name](#output\_s3\_logging\_bucket\_name) | The name of our shared logging bucket |
+| <a name="output_shared_ci_policy_arn"></a> [shared\_ci\_policy\_arn](#output\_shared\_ci\_policy\_arn) | The arn of our ci policy consumed by our codebuild jobs |
 <!-- END_TF_DOCS -->

--- a/terraform/shared_account_pathtolive_infra/README.md
+++ b/terraform/shared_account_pathtolive_infra/README.md
@@ -24,102 +24,104 @@ a `qsolutions-auth` profile set up in Aws-Vault. You will also need `jq` install
 For the delegated hosted zone parent see [this readme](../shared_account_sandbox_infra/README.md)
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | ~> 2.2.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.1.0 |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
+| <a name="requirement_local"></a> [local](#requirement_local)             | ~> 2.0.0 |
+| <a name="requirement_null"></a> [null](#requirement_null)                | ~> 3.0.0 |
+| <a name="requirement_template"></a> [template](#requirement_template)    | ~> 2.2.0 |
+| <a name="requirement_tls"></a> [tls](#requirement_tls)                   | ~> 3.1.0 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_aws.integration_baseline"></a> [aws.integration\_baseline](#provider\_aws.integration\_baseline) | 3.75.2 |
-| <a name="provider_aws.integration_next"></a> [aws.integration\_next](#provider\_aws.integration\_next) | 3.75.2 |
-| <a name="provider_aws.preprod"></a> [aws.preprod](#provider\_aws.preprod) | 3.75.2 |
-| <a name="provider_aws.production"></a> [aws.production](#provider\_aws.production) | 3.75.2 |
-| <a name="provider_aws.sandbox"></a> [aws.sandbox](#provider\_aws.sandbox) | 3.75.2 |
-| <a name="provider_aws.shared"></a> [aws.shared](#provider\_aws.shared) | 3.75.2 |
+| Name                                                                                                            | Version |
+| --------------------------------------------------------------------------------------------------------------- | ------- |
+| <a name="provider_aws"></a> [aws](#provider_aws)                                                                | 3.75.2  |
+| <a name="provider_aws.integration_baseline"></a> [aws.integration_baseline](#provider_aws.integration_baseline) | 3.75.2  |
+| <a name="provider_aws.integration_next"></a> [aws.integration_next](#provider_aws.integration_next)             | 3.75.2  |
+| <a name="provider_aws.preprod"></a> [aws.preprod](#provider_aws.preprod)                                        | 3.75.2  |
+| <a name="provider_aws.production"></a> [aws.production](#provider_aws.production)                               | 3.75.2  |
+| <a name="provider_aws.sandbox"></a> [aws.sandbox](#provider_aws.sandbox)                                        | 3.75.2  |
+| <a name="provider_aws.shared"></a> [aws.shared](#provider_aws.shared)                                           | 3.75.2  |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_aws_logs"></a> [aws\_logs](#module\_aws\_logs) | trussworks/logs/aws | ~> 10.3.0  |
-| <a name="module_integration_baseline_child_access"></a> [integration\_baseline\_child\_access](#module\_integration\_baseline\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
-| <a name="module_integration_next_child_access"></a> [integration\_next\_child\_access](#module\_integration\_next\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
-| <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_preprod_child_access"></a> [preprod\_child\_access](#module\_preprod\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
-| <a name="module_production_child_access"></a> [production\_child\_access](#module\_production\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
-| <a name="module_shared_account_access_integration_baseline"></a> [shared\_account\_access\_integration\_baseline](#module\_shared\_account\_access\_integration\_baseline) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
-| <a name="module_shared_account_access_integration_baseline_lambda_cloudtrail"></a> [shared\_account\_access\_integration\_baseline\_lambda\_cloudtrail](#module\_shared\_account\_access\_integration\_baseline\_lambda\_cloudtrail) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail | n/a |
-| <a name="module_shared_account_access_integration_next"></a> [shared\_account\_access\_integration\_next](#module\_shared\_account\_access\_integration\_next) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
-| <a name="module_shared_account_access_integration_next_lambda_cloudtrail"></a> [shared\_account\_access\_integration\_next\_lambda\_cloudtrail](#module\_shared\_account\_access\_integration\_next\_lambda\_cloudtrail) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail | n/a |
-| <a name="module_shared_account_access_preprod"></a> [shared\_account\_access\_preprod](#module\_shared\_account\_access\_preprod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
-| <a name="module_shared_account_access_production"></a> [shared\_account\_access\_production](#module\_shared\_account\_access\_production) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
-| <a name="module_shared_account_preprod_lambda_cloudtrail"></a> [shared\_account\_preprod\_lambda\_cloudtrail](#module\_shared\_account\_preprod\_lambda\_cloudtrail) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail | n/a |
-| <a name="module_shared_account_production_next_lambda_cloudtrail"></a> [shared\_account\_production\_next\_lambda\_cloudtrail](#module\_shared\_account\_production\_next\_lambda\_cloudtrail) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail | n/a |
-| <a name="module_shared_account_user_access"></a> [shared\_account\_user\_access](#module\_shared\_account\_user\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent | n/a |
-| <a name="module_tag_vars"></a> [tag\_vars](#module\_tag\_vars) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars | n/a |
+| Name                                                                                                                                                                                                                    | Source                                                                                                      | Version   |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | --------- |
+| <a name="module_aws_logs"></a> [aws_logs](#module_aws_logs)                                                                                                                                                             | trussworks/logs/aws                                                                                         | ~> 10.3.0 |
+| <a name="module_integration_baseline_child_access"></a> [integration_baseline_child_access](#module_integration_baseline_child_access)                                                                                  | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
+| <a name="module_integration_next_child_access"></a> [integration_next_child_access](#module_integration_next_child_access)                                                                                              | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
+| <a name="module_label"></a> [label](#module_label)                                                                                                                                                                      | cloudposse/label/null                                                                                       | 0.24.1    |
+| <a name="module_preprod_child_access"></a> [preprod_child_access](#module_preprod_child_access)                                                                                                                         | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
+| <a name="module_production_child_access"></a> [production_child_access](#module_production_child_access)                                                                                                                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
+| <a name="module_shared_account_access_integration_baseline"></a> [shared_account_access_integration_baseline](#module_shared_account_access_integration_baseline)                                                       | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
+| <a name="module_shared_account_access_integration_baseline_lambda_cloudtrail"></a> [shared_account_access_integration_baseline_lambda_cloudtrail](#module_shared_account_access_integration_baseline_lambda_cloudtrail) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail            | n/a       |
+| <a name="module_shared_account_access_integration_next"></a> [shared_account_access_integration_next](#module_shared_account_access_integration_next)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
+| <a name="module_shared_account_access_integration_next_lambda_cloudtrail"></a> [shared_account_access_integration_next_lambda_cloudtrail](#module_shared_account_access_integration_next_lambda_cloudtrail)             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail            | n/a       |
+| <a name="module_shared_account_access_preprod"></a> [shared_account_access_preprod](#module_shared_account_access_preprod)                                                                                              | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
+| <a name="module_shared_account_access_production"></a> [shared_account_access_production](#module_shared_account_access_production)                                                                                     | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
+| <a name="module_shared_account_preprod_lambda_cloudtrail"></a> [shared_account_preprod_lambda_cloudtrail](#module_shared_account_preprod_lambda_cloudtrail)                                                             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail            | n/a       |
+| <a name="module_shared_account_production_next_lambda_cloudtrail"></a> [shared_account_production_next_lambda_cloudtrail](#module_shared_account_production_next_lambda_cloudtrail)                                     | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_cloudtrail            | n/a       |
+| <a name="module_shared_account_user_access"></a> [shared_account_user_access](#module_shared_account_user_access)                                                                                                       | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent        | n/a       |
+| <a name="module_tag_vars"></a> [tag_vars](#module_tag_vars)                                                                                                                                                             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars                     | n/a       |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_route53_record.bichard7_pathtolive_name_servers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_route53_zone.bichard7_pathtolive_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.integration_baseline](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.integration_next](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.production](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
-| [aws_ssm_parameter.non_sc_users](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter) | data source |
+| Name                                                                                                                                              | Type        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_route53_record.bichard7_pathtolive_name_servers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource    |
+| [aws_route53_zone.bichard7_pathtolive_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone)   | resource    |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                     | data source |
+| [aws_caller_identity.integration_baseline](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)        | data source |
+| [aws_caller_identity.integration_next](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)            | data source |
+| [aws_caller_identity.preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                     | data source |
+| [aws_caller_identity.production](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                  | data source |
+| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                | data source |
+| [aws_ssm_parameter.non_sc_users](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter)                    | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_integration_baseline_access_key"></a> [integration\_baseline\_access\_key](#input\_integration\_baseline\_access\_key) | the AWS\_ACCESS\_KEY\_ID for integration\_baseline | `string` | n/a | yes |
-| <a name="input_integration_baseline_secret_key"></a> [integration\_baseline\_secret\_key](#input\_integration\_baseline\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for integration\_baseline | `string` | n/a | yes |
-| <a name="input_integration_next_access_key"></a> [integration\_next\_access\_key](#input\_integration\_next\_access\_key) | the AWS\_ACCESS\_KEY\_ID for integration\_next | `string` | n/a | yes |
-| <a name="input_integration_next_secret_key"></a> [integration\_next\_secret\_key](#input\_integration\_next\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for integration\_next | `string` | n/a | yes |
-| <a name="input_parent_zone_id"></a> [parent\_zone\_id](#input\_parent\_zone\_id) | The zone id of our parent hosted zone | `string` | `"Z0532960253T16WMNSRNR"` | no |
-| <a name="input_preprod_access_key"></a> [preprod\_access\_key](#input\_preprod\_access\_key) | the AWS\_ACCESS\_KEY\_ID for Q Solution preprod | `string` | n/a | yes |
-| <a name="input_preprod_secret_key"></a> [preprod\_secret\_key](#input\_preprod\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for Q Solution preprod | `string` | n/a | yes |
-| <a name="input_preprod_session_token"></a> [preprod\_session\_token](#input\_preprod\_session\_token) | the AWS\_SESSION\_TOKEN for Q Solution preprod | `string` | n/a | yes |
-| <a name="input_production_access_key"></a> [production\_access\_key](#input\_production\_access\_key) | the AWS\_ACCESS\_KEY\_ID for Q Solution production | `string` | n/a | yes |
-| <a name="input_production_secret_key"></a> [production\_secret\_key](#input\_production\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for Q Solution production | `string` | n/a | yes |
-| <a name="input_production_session_token"></a> [production\_session\_token](#input\_production\_session\_token) | the AWS\_SESSION\_TOKEN for Q Solution production | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | The AWS region | `string` | `"eu-west-2"` | no |
-| <a name="input_slack_webhook"></a> [slack\_webhook](#input\_slack\_webhook) | Our webhook for sending messages to slack | `string` | `""` | no |
+| Name                                                                                                                           | Description                                         | Type     | Default                   | Required |
+| ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- | -------- | ------------------------- | :------: |
+| <a name="input_integration_baseline_access_key"></a> [integration_baseline_access_key](#input_integration_baseline_access_key) | the AWS_ACCESS_KEY_ID for integration_baseline      | `string` | n/a                       |   yes    |
+| <a name="input_integration_baseline_secret_key"></a> [integration_baseline_secret_key](#input_integration_baseline_secret_key) | the AWS_SECRET_ACCESS_KEY for integration_baseline  | `string` | n/a                       |   yes    |
+| <a name="input_integration_next_access_key"></a> [integration_next_access_key](#input_integration_next_access_key)             | the AWS_ACCESS_KEY_ID for integration_next          | `string` | n/a                       |   yes    |
+| <a name="input_integration_next_secret_key"></a> [integration_next_secret_key](#input_integration_next_secret_key)             | the AWS_SECRET_ACCESS_KEY for integration_next      | `string` | n/a                       |   yes    |
+| <a name="input_parent_zone_id"></a> [parent_zone_id](#input_parent_zone_id)                                                    | The zone id of our parent hosted zone               | `string` | `"Z0532960253T16WMNSRNR"` |    no    |
+| <a name="input_preprod_access_key"></a> [preprod_access_key](#input_preprod_access_key)                                        | the AWS_ACCESS_KEY_ID for Q Solution preprod        | `string` | n/a                       |   yes    |
+| <a name="input_preprod_secret_key"></a> [preprod_secret_key](#input_preprod_secret_key)                                        | the AWS_SECRET_ACCESS_KEY for Q Solution preprod    | `string` | n/a                       |   yes    |
+| <a name="input_preprod_session_token"></a> [preprod_session_token](#input_preprod_session_token)                               | the AWS_SESSION_TOKEN for Q Solution preprod        | `string` | n/a                       |   yes    |
+| <a name="input_production_access_key"></a> [production_access_key](#input_production_access_key)                               | the AWS_ACCESS_KEY_ID for Q Solution production     | `string` | n/a                       |   yes    |
+| <a name="input_production_secret_key"></a> [production_secret_key](#input_production_secret_key)                               | the AWS_SECRET_ACCESS_KEY for Q Solution production | `string` | n/a                       |   yes    |
+| <a name="input_production_session_token"></a> [production_session_token](#input_production_session_token)                      | the AWS_SESSION_TOKEN for Q Solution production     | `string` | n/a                       |   yes    |
+| <a name="input_region"></a> [region](#input_region)                                                                            | The AWS region                                      | `string` | `"eu-west-2"`             |    no    |
+| <a name="input_slack_webhook"></a> [slack_webhook](#input_slack_webhook)                                                       | Our webhook for sending messages to slack           | `string` | `""`                      |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_admin_group_name"></a> [admin\_group\_name](#output\_admin\_group\_name) | The name of our admin group |
-| <a name="output_ci_group_name"></a> [ci\_group\_name](#output\_ci\_group\_name) | The name of our ci group |
-| <a name="output_ci_users"></a> [ci\_users](#output\_ci\_users) | A list of our CI users |
-| <a name="output_delegated_hosted_zone"></a> [delegated\_hosted\_zone](#output\_delegated\_hosted\_zone) | Our pathtolive hosted zone |
-| <a name="output_integration_baseline_admin_arn"></a> [integration\_baseline\_admin\_arn](#output\_integration\_baseline\_admin\_arn) | The integration\_baseline Admin Assume Role ARN |
-| <a name="output_integration_baseline_ci_arn"></a> [integration\_baseline\_ci\_arn](#output\_integration\_baseline\_ci\_arn) | The integration\_baseline CI Assume Role ARN |
-| <a name="output_integration_baseline_readonly_arn"></a> [integration\_baseline\_readonly\_arn](#output\_integration\_baseline\_readonly\_arn) | The integration\_baseline ReadOnly Assume Role ARN |
-| <a name="output_integration_next_admin_arn"></a> [integration\_next\_admin\_arn](#output\_integration\_next\_admin\_arn) | The integration\_next Admin Assume Role ARN |
-| <a name="output_integration_next_ci_arn"></a> [integration\_next\_ci\_arn](#output\_integration\_next\_ci\_arn) | The integration\_next CI Assume Role ARN |
-| <a name="output_integration_next_readonly_arn"></a> [integration\_next\_readonly\_arn](#output\_integration\_next\_readonly\_arn) | The integration\_next ReadOnly Assume Role ARN |
-| <a name="output_mfa_group_name"></a> [mfa\_group\_name](#output\_mfa\_group\_name) | The name of our MFA group |
-| <a name="output_preprod_admin_arn"></a> [preprod\_admin\_arn](#output\_preprod\_admin\_arn) | The preprod Admin Assume Role ARN |
-| <a name="output_preprod_ci_arn"></a> [preprod\_ci\_arn](#output\_preprod\_ci\_arn) | The preprod CI Assume Role ARN |
-| <a name="output_production_admin_arn"></a> [production\_admin\_arn](#output\_production\_admin\_arn) | The production Admin Assume Role ARN |
-| <a name="output_production_ci_arn"></a> [production\_ci\_arn](#output\_production\_ci\_arn) | The production CI Assume Role ARN |
-| <a name="output_readonly_group_name"></a> [readonly\_group\_name](#output\_readonly\_group\_name) | The name of our readonly group |
-| <a name="output_s3_logging_bucket_name"></a> [s3\_logging\_bucket\_name](#output\_s3\_logging\_bucket\_name) | The name of our shared logging bucket |
-| <a name="output_shared_ci_policy_arn"></a> [shared\_ci\_policy\_arn](#output\_shared\_ci\_policy\_arn) | The arn of our ci policy consumed by our codebuild jobs |
+| Name                                                                                                                                   | Description                                             |
+| -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| <a name="output_admin_group_name"></a> [admin_group_name](#output_admin_group_name)                                                    | The name of our admin group                             |
+| <a name="output_ci_group_name"></a> [ci_group_name](#output_ci_group_name)                                                             | The name of our ci group                                |
+| <a name="output_ci_users"></a> [ci_users](#output_ci_users)                                                                            | A list of our CI users                                  |
+| <a name="output_delegated_hosted_zone"></a> [delegated_hosted_zone](#output_delegated_hosted_zone)                                     | Our pathtolive hosted zone                              |
+| <a name="output_integration_baseline_admin_arn"></a> [integration_baseline_admin_arn](#output_integration_baseline_admin_arn)          | The integration_baseline Admin Assume Role ARN          |
+| <a name="output_integration_baseline_ci_arn"></a> [integration_baseline_ci_arn](#output_integration_baseline_ci_arn)                   | The integration_baseline CI Assume Role ARN             |
+| <a name="output_integration_baseline_readonly_arn"></a> [integration_baseline_readonly_arn](#output_integration_baseline_readonly_arn) | The integration_baseline ReadOnly Assume Role ARN       |
+| <a name="output_integration_next_admin_arn"></a> [integration_next_admin_arn](#output_integration_next_admin_arn)                      | The integration_next Admin Assume Role ARN              |
+| <a name="output_integration_next_ci_arn"></a> [integration_next_ci_arn](#output_integration_next_ci_arn)                               | The integration_next CI Assume Role ARN                 |
+| <a name="output_integration_next_readonly_arn"></a> [integration_next_readonly_arn](#output_integration_next_readonly_arn)             | The integration_next ReadOnly Assume Role ARN           |
+| <a name="output_mfa_group_name"></a> [mfa_group_name](#output_mfa_group_name)                                                          | The name of our MFA group                               |
+| <a name="output_preprod_admin_arn"></a> [preprod_admin_arn](#output_preprod_admin_arn)                                                 | The preprod Admin Assume Role ARN                       |
+| <a name="output_preprod_ci_arn"></a> [preprod_ci_arn](#output_preprod_ci_arn)                                                          | The preprod CI Assume Role ARN                          |
+| <a name="output_production_admin_arn"></a> [production_admin_arn](#output_production_admin_arn)                                        | The production Admin Assume Role ARN                    |
+| <a name="output_production_ci_arn"></a> [production_ci_arn](#output_production_ci_arn)                                                 | The production CI Assume Role ARN                       |
+| <a name="output_readonly_group_name"></a> [readonly_group_name](#output_readonly_group_name)                                           | The name of our readonly group                          |
+| <a name="output_s3_logging_bucket_name"></a> [s3_logging_bucket_name](#output_s3_logging_bucket_name)                                  | The name of our shared logging bucket                   |
+| <a name="output_shared_ci_policy_arn"></a> [shared_ci_policy_arn](#output_shared_ci_policy_arn)                                        | The arn of our ci policy consumed by our codebuild jobs |
+
 <!-- END_TF_DOCS -->

--- a/terraform/shared_account_pathtolive_infra_ci/README.md
+++ b/terraform/shared_account_pathtolive_infra_ci/README.md
@@ -3,179 +3,177 @@
 Creates various codebuild/codepipeline jobs and a codebuild vpc for our path to live account
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version  |
-| ------------------------------------------------------------------------ | -------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
-| <a name="requirement_local"></a> [local](#requirement_local)             | ~> 2.0.0 |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0.0 |
 
 ## Providers
 
-| Name                                                                                                            | Version  |
-| --------------------------------------------------------------------------------------------------------------- | -------- |
-| <a name="provider_aws"></a> [aws](#provider_aws)                                                                | = 3.75.2 |
-| <a name="provider_aws.integration_baseline"></a> [aws.integration_baseline](#provider_aws.integration_baseline) | = 3.75.2 |
-| <a name="provider_aws.integration_next"></a> [aws.integration_next](#provider_aws.integration_next)             | = 3.75.2 |
-| <a name="provider_aws.production"></a> [aws.production](#provider_aws.production)                               | = 3.75.2 |
-| <a name="provider_aws.qsolution"></a> [aws.qsolution](#provider_aws.qsolution)                                  | = 3.75.2 |
-| <a name="provider_external"></a> [external](#provider_external)                                                 | n/a      |
-| <a name="provider_template"></a> [template](#provider_template)                                                 | n/a      |
-| <a name="provider_terraform"></a> [terraform](#provider_terraform)                                              | n/a      |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
+| <a name="provider_aws.integration_baseline"></a> [aws.integration\_baseline](#provider\_aws.integration\_baseline) | 3.75.2 |
+| <a name="provider_aws.integration_next"></a> [aws.integration\_next](#provider\_aws.integration\_next) | 3.75.2 |
+| <a name="provider_aws.production"></a> [aws.production](#provider\_aws.production) | 3.75.2 |
+| <a name="provider_aws.qsolution"></a> [aws.qsolution](#provider\_aws.qsolution) | 3.75.2 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.1.0 |
+| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
-| Name                                                                                                                                                                       | Source                                                                                                  | Version |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------- |
-| <a name="module_apply_dev_sg_to_e2e_test"></a> [apply_dev_sg_to_e2e_test](#module_apply_dev_sg_to_e2e_test)                                                                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_apply_dev_sg_to_load_test"></a> [apply_dev_sg_to_load_test](#module_apply_dev_sg_to_load_test)                                                             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_apply_dev_sg_to_preprod"></a> [apply_dev_sg_to_preprod](#module_apply_dev_sg_to_preprod)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_apply_dev_sg_to_prod"></a> [apply_dev_sg_to_prod](#module_apply_dev_sg_to_prod)                                                                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_build_ci_monitoring"></a> [build_ci_monitoring](#module_build_ci_monitoring)                                                                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_build_ci_monitoring_schedule"></a> [build_ci_monitoring_schedule](#module_build_ci_monitoring_schedule)                                                    | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_build_nginx_scan_portal"></a> [build_nginx_scan_portal](#module_build_nginx_scan_portal)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_code_to_be_deployed"></a> [code_to_be_deployed](#module_code_to_be_deployed)                                                                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_codebuild_base_resources"></a> [codebuild_base_resources](#module_codebuild_base_resources)                                                                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_base_resources | n/a     |
-| <a name="module_codebuild_docker_resources"></a> [codebuild_docker_resources](#module_codebuild_docker_resources)                                                          | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/aws_ecr_repositories     | n/a     |
-| <a name="module_common_build_jobs"></a> [common_build_jobs](#module_common_build_jobs)                                                                                     | ../modules/shared_cd_common_jobs                                                                        | n/a     |
-| <a name="module_deploy_e2e_test_terraform"></a> [deploy_e2e_test_terraform](#module_deploy_e2e_test_terraform)                                                             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_deploy_load_test_terraform"></a> [deploy_load_test_terraform](#module_deploy_load_test_terraform)                                                          | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_deploy_preprod_terraform"></a> [deploy_preprod_terraform](#module_deploy_preprod_terraform)                                                                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_deploy_production_terraform"></a> [deploy_production_terraform](#module_deploy_production_terraform)                                                       | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_destroy_e2e_test_terraform"></a> [destroy_e2e_test_terraform](#module_destroy_e2e_test_terraform)                                                          | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_destroy_load_test_terraform"></a> [destroy_load_test_terraform](#module_destroy_load_test_terraform)                                                       | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_destroy_preprod_terraform"></a> [destroy_preprod_terraform](#module_destroy_preprod_terraform)                                                             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_destroy_production_terraform"></a> [destroy_production_terraform](#module_destroy_production_terraform)                                                    | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_disable_maintenance_page_preprod"></a> [disable_maintenance_page_preprod](#module_disable_maintenance_page_preprod)                                        | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_disable_maintenance_page_prod"></a> [disable_maintenance_page_prod](#module_disable_maintenance_page_prod)                                                 | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_ecs_scanning_portal"></a> [ecs_scanning_portal](#module_ecs_scanning_portal)                                                                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules//scanning_results_ecs    | n/a     |
-| <a name="module_enable_maintenance_page_preprod"></a> [enable_maintenance_page_preprod](#module_enable_maintenance_page_preprod)                                           | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_enable_maintenance_page_prod"></a> [enable_maintenance_page_prod](#module_enable_maintenance_page_prod)                                                    | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_label"></a> [label](#module_label)                                                                                                                         | cloudposse/label/null                                                                                   | 0.24.1  |
-| <a name="module_notify_pipeline"></a> [notify_pipeline](#module_notify_pipeline)                                                                                           | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codestar_notification    | n/a     |
-| <a name="module_owasp_scan_e2e_test"></a> [owasp_scan_e2e_test](#module_owasp_scan_e2e_test)                                                                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_owasp_scan_e2e_test_audit_logging"></a> [owasp_scan_e2e_test_audit_logging](#module_owasp_scan_e2e_test_audit_logging)                                     | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_owasp_scan_e2e_test_audit_logging_trigger"></a> [owasp_scan_e2e_test_audit_logging_trigger](#module_owasp_scan_e2e_test_audit_logging_trigger)             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_owasp_scan_e2e_test_trigger"></a> [owasp_scan_e2e_test_trigger](#module_owasp_scan_e2e_test_trigger)                                                       | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_owasp_scan_e2e_test_user_service"></a> [owasp_scan_e2e_test_user_service](#module_owasp_scan_e2e_test_user_service)                                        | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_owasp_scan_e2e_test_user_service_trigger"></a> [owasp_scan_e2e_test_user_service_trigger](#module_owasp_scan_e2e_test_user_service_trigger)                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_remove_dev_sg_from_e2e_test"></a> [remove_dev_sg_from_e2e_test](#module_remove_dev_sg_from_e2e_test)                                                       | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_remove_dev_sg_from_e2e_test_schedule"></a> [remove_dev_sg_from_e2e_test_schedule](#module_remove_dev_sg_from_e2e_test_schedule)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_remove_dev_sg_from_load_test"></a> [remove_dev_sg_from_load_test](#module_remove_dev_sg_from_load_test)                                                    | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_remove_dev_sg_from_preprod"></a> [remove_dev_sg_from_preprod](#module_remove_dev_sg_from_preprod)                                                          | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_remove_dev_sg_from_preprod_schedule"></a> [remove_dev_sg_from_preprod_schedule](#module_remove_dev_sg_from_preprod_schedule)                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_remove_dev_sg_from_prod"></a> [remove_dev_sg_from_prod](#module_remove_dev_sg_from_prod)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_remove_dev_sg_from_prod_schedule"></a> [remove_dev_sg_from_prod_schedule](#module_remove_dev_sg_from_prod_schedule)                                        | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_run_destroy_load_test_env_schedule"></a> [run_destroy_load_test_env_schedule](#module_run_destroy_load_test_env_schedule)                                  | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_run_e2e_test_migrations"></a> [run_e2e_test_migrations](#module_run_e2e_test_migrations)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_run_e2e_tests"></a> [run_e2e_tests](#module_run_e2e_tests)                                                                                                 | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_run_e2e_tests_restart_pnc_container"></a> [run_e2e_tests_restart_pnc_container](#module_run_e2e_tests_restart_pnc_container)                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_run_e2e_tests_schedule"></a> [run_e2e_tests_schedule](#module_run_e2e_tests_schedule)                                                                      | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_run_load_test_migrations"></a> [run_load_test_migrations](#module_run_load_test_migrations)                                                                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_run_load_tests"></a> [run_load_tests](#module_run_load_tests)                                                                                              | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_run_load_tests_terminate_pnc_container"></a> [run_load_tests_terminate_pnc_container](#module_run_load_tests_terminate_pnc_container)                      | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_run_preprod_migrations"></a> [run_preprod_migrations](#module_run_preprod_migrations)                                                                      | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_run_preprod_tests"></a> [run_preprod_tests](#module_run_preprod_tests)                                                                                     | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_run_prod_smoketests"></a> [run_prod_smoketests](#module_run_prod_smoketests)                                                                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_run_production_migrations"></a> [run_production_migrations](#module_run_production_migrations)                                                             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_scoutsuite_scan_integration_baseline"></a> [scoutsuite_scan_integration_baseline](#module_scoutsuite_scan_integration_baseline)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_scoutsuite_scan_integration_baseline_schedule"></a> [scoutsuite_scan_integration_baseline_schedule](#module_scoutsuite_scan_integration_baseline_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_scoutsuite_scan_integration_next"></a> [scoutsuite_scan_integration_next](#module_scoutsuite_scan_integration_next)                                        | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_scoutsuite_scan_integration_next_schedule"></a> [scoutsuite_scan_integration_next_schedule](#module_scoutsuite_scan_integration_next_schedule)             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_scoutsuite_scan_shared"></a> [scoutsuite_scan_shared](#module_scoutsuite_scan_shared)                                                                      | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_scoutsuite_scan_shared_schedule"></a> [scoutsuite_scan_shared_schedule](#module_scoutsuite_scan_shared_schedule)                                           | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_self_signed_certificate"></a> [self_signed_certificate](#module_self_signed_certificate)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/self_signed_certificate  | n/a     |
-| <a name="module_tag_vars"></a> [tag_vars](#module_tag_vars)                                                                                                                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars                 | n/a     |
-| <a name="module_update_environment_ssm_params"></a> [update_environment_ssm_params](#module_update_environment_ssm_params)                                                 | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_apply_dev_sg_to_e2e_test"></a> [apply\_dev\_sg\_to\_e2e\_test](#module\_apply\_dev\_sg\_to\_e2e\_test) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_apply_dev_sg_to_load_test"></a> [apply\_dev\_sg\_to\_load\_test](#module\_apply\_dev\_sg\_to\_load\_test) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_apply_dev_sg_to_preprod"></a> [apply\_dev\_sg\_to\_preprod](#module\_apply\_dev\_sg\_to\_preprod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_apply_dev_sg_to_prod"></a> [apply\_dev\_sg\_to\_prod](#module\_apply\_dev\_sg\_to\_prod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_build_ci_monitoring"></a> [build\_ci\_monitoring](#module\_build\_ci\_monitoring) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_build_ci_monitoring_schedule"></a> [build\_ci\_monitoring\_schedule](#module\_build\_ci\_monitoring\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_build_nginx_scan_portal"></a> [build\_nginx\_scan\_portal](#module\_build\_nginx\_scan\_portal) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_code_to_be_deployed"></a> [code\_to\_be\_deployed](#module\_code\_to\_be\_deployed) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_codebuild_base_resources"></a> [codebuild\_base\_resources](#module\_codebuild\_base\_resources) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_base_resources | n/a |
+| <a name="module_codebuild_docker_resources"></a> [codebuild\_docker\_resources](#module\_codebuild\_docker\_resources) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/aws_ecr_repositories | n/a |
+| <a name="module_common_build_jobs"></a> [common\_build\_jobs](#module\_common\_build\_jobs) | ../modules/shared_cd_common_jobs | n/a |
+| <a name="module_deploy_e2e_test_terraform"></a> [deploy\_e2e\_test\_terraform](#module\_deploy\_e2e\_test\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_deploy_load_test_terraform"></a> [deploy\_load\_test\_terraform](#module\_deploy\_load\_test\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_deploy_preprod_terraform"></a> [deploy\_preprod\_terraform](#module\_deploy\_preprod\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_deploy_production_terraform"></a> [deploy\_production\_terraform](#module\_deploy\_production\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_destroy_e2e_test_terraform"></a> [destroy\_e2e\_test\_terraform](#module\_destroy\_e2e\_test\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_destroy_load_test_terraform"></a> [destroy\_load\_test\_terraform](#module\_destroy\_load\_test\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_destroy_preprod_terraform"></a> [destroy\_preprod\_terraform](#module\_destroy\_preprod\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_destroy_production_terraform"></a> [destroy\_production\_terraform](#module\_destroy\_production\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_disable_maintenance_page_preprod"></a> [disable\_maintenance\_page\_preprod](#module\_disable\_maintenance\_page\_preprod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_disable_maintenance_page_prod"></a> [disable\_maintenance\_page\_prod](#module\_disable\_maintenance\_page\_prod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_ecs_scanning_portal"></a> [ecs\_scanning\_portal](#module\_ecs\_scanning\_portal) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules//scanning_results_ecs | n/a |
+| <a name="module_enable_maintenance_page_preprod"></a> [enable\_maintenance\_page\_preprod](#module\_enable\_maintenance\_page\_preprod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_enable_maintenance_page_prod"></a> [enable\_maintenance\_page\_prod](#module\_enable\_maintenance\_page\_prod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_notify_pipeline"></a> [notify\_pipeline](#module\_notify\_pipeline) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codestar_notification | n/a |
+| <a name="module_owasp_scan_e2e_test"></a> [owasp\_scan\_e2e\_test](#module\_owasp\_scan\_e2e\_test) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_owasp_scan_e2e_test_audit_logging"></a> [owasp\_scan\_e2e\_test\_audit\_logging](#module\_owasp\_scan\_e2e\_test\_audit\_logging) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_owasp_scan_e2e_test_audit_logging_trigger"></a> [owasp\_scan\_e2e\_test\_audit\_logging\_trigger](#module\_owasp\_scan\_e2e\_test\_audit\_logging\_trigger) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_owasp_scan_e2e_test_trigger"></a> [owasp\_scan\_e2e\_test\_trigger](#module\_owasp\_scan\_e2e\_test\_trigger) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_owasp_scan_e2e_test_user_service"></a> [owasp\_scan\_e2e\_test\_user\_service](#module\_owasp\_scan\_e2e\_test\_user\_service) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_owasp_scan_e2e_test_user_service_trigger"></a> [owasp\_scan\_e2e\_test\_user\_service\_trigger](#module\_owasp\_scan\_e2e\_test\_user\_service\_trigger) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_remove_dev_sg_from_e2e_test"></a> [remove\_dev\_sg\_from\_e2e\_test](#module\_remove\_dev\_sg\_from\_e2e\_test) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_remove_dev_sg_from_e2e_test_schedule"></a> [remove\_dev\_sg\_from\_e2e\_test\_schedule](#module\_remove\_dev\_sg\_from\_e2e\_test\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_remove_dev_sg_from_load_test"></a> [remove\_dev\_sg\_from\_load\_test](#module\_remove\_dev\_sg\_from\_load\_test) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_remove_dev_sg_from_preprod"></a> [remove\_dev\_sg\_from\_preprod](#module\_remove\_dev\_sg\_from\_preprod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_remove_dev_sg_from_preprod_schedule"></a> [remove\_dev\_sg\_from\_preprod\_schedule](#module\_remove\_dev\_sg\_from\_preprod\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_remove_dev_sg_from_prod"></a> [remove\_dev\_sg\_from\_prod](#module\_remove\_dev\_sg\_from\_prod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_remove_dev_sg_from_prod_schedule"></a> [remove\_dev\_sg\_from\_prod\_schedule](#module\_remove\_dev\_sg\_from\_prod\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_run_destroy_load_test_env_schedule"></a> [run\_destroy\_load\_test\_env\_schedule](#module\_run\_destroy\_load\_test\_env\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_run_e2e_test_migrations"></a> [run\_e2e\_test\_migrations](#module\_run\_e2e\_test\_migrations) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_run_e2e_tests"></a> [run\_e2e\_tests](#module\_run\_e2e\_tests) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_run_e2e_tests_restart_pnc_container"></a> [run\_e2e\_tests\_restart\_pnc\_container](#module\_run\_e2e\_tests\_restart\_pnc\_container) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_run_e2e_tests_schedule"></a> [run\_e2e\_tests\_schedule](#module\_run\_e2e\_tests\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_run_load_test_migrations"></a> [run\_load\_test\_migrations](#module\_run\_load\_test\_migrations) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_run_load_tests"></a> [run\_load\_tests](#module\_run\_load\_tests) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_run_load_tests_terminate_pnc_container"></a> [run\_load\_tests\_terminate\_pnc\_container](#module\_run\_load\_tests\_terminate\_pnc\_container) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_run_preprod_migrations"></a> [run\_preprod\_migrations](#module\_run\_preprod\_migrations) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_run_preprod_tests"></a> [run\_preprod\_tests](#module\_run\_preprod\_tests) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_run_prod_smoketests"></a> [run\_prod\_smoketests](#module\_run\_prod\_smoketests) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_run_production_migrations"></a> [run\_production\_migrations](#module\_run\_production\_migrations) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_scoutsuite_scan_integration_baseline"></a> [scoutsuite\_scan\_integration\_baseline](#module\_scoutsuite\_scan\_integration\_baseline) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_scoutsuite_scan_integration_baseline_schedule"></a> [scoutsuite\_scan\_integration\_baseline\_schedule](#module\_scoutsuite\_scan\_integration\_baseline\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_scoutsuite_scan_integration_next"></a> [scoutsuite\_scan\_integration\_next](#module\_scoutsuite\_scan\_integration\_next) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_scoutsuite_scan_integration_next_schedule"></a> [scoutsuite\_scan\_integration\_next\_schedule](#module\_scoutsuite\_scan\_integration\_next\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_scoutsuite_scan_shared"></a> [scoutsuite\_scan\_shared](#module\_scoutsuite\_scan\_shared) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_scoutsuite_scan_shared_schedule"></a> [scoutsuite\_scan\_shared\_schedule](#module\_scoutsuite\_scan\_shared\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_self_signed_certificate"></a> [self\_signed\_certificate](#module\_self\_signed\_certificate) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/self_signed_certificate | n/a |
+| <a name="module_tag_vars"></a> [tag\_vars](#module\_tag\_vars) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars | n/a |
+| <a name="module_update_environment_ssm_params"></a> [update\_environment\_ssm\_params](#module\_update\_environment\_ssm\_params) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
 
 ## Resources
 
-| Name                                                                                                                                                                        | Type        |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [aws_acm_certificate.bichard7_pathtolive_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/acm_certificate)                       | resource    |
-| [aws_acm_certificate_validation.base_infra_certificate_validation](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/acm_certificate_validation)  | resource    |
-| [aws_codebuild_webhook.e2e_tests_pr_webhook](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/codebuild_webhook)                                 | resource    |
-| [aws_codepipeline.path_to_live](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/codepipeline)                                                   | resource    |
-| [aws_codestarconnections_connection.github](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/codestarconnections_connection)                     | resource    |
-| [aws_iam_role.codepipeline_role](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role)                                                      | resource    |
-| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_e2e_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)       | resource    |
-| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_load_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)      | resource    |
-| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_pre_prod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)       | resource    |
-| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_production](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)     | resource    |
-| [aws_iam_role_policy.allow_code_pipeline_connection_for_load_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)            | resource    |
-| [aws_iam_role_policy.allow_code_pipeline_connection_for_production_smoketests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource    |
-| [aws_iam_role_policy.allow_integration_baseline_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)              | resource    |
-| [aws_iam_role_policy.allow_integration_next_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                  | resource    |
-| [aws_iam_role_policy.allow_production_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                        | resource    |
-| [aws_iam_role_policy.allow_qsolution_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                         | resource    |
-| [aws_iam_role_policy.apply_dev_sg_to_e2e_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                 | resource    |
-| [aws_iam_role_policy.apply_dev_sg_to_preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                  | resource    |
-| [aws_iam_role_policy.code_to_be_deployed](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                      | resource    |
-| [aws_iam_role_policy.codepipeline_policy](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                      | resource    |
-| [aws_iam_role_policy.remove_dev_sg_from_e2e_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                              | resource    |
-| [aws_iam_role_policy.remove_dev_sg_from_preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                               | resource    |
-| [aws_iam_role_policy.restart_pnc_emulator_e2e_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                           | resource    |
-| [aws_iam_role_policy.run_e2e_test_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                  | resource    |
-| [aws_iam_role_policy.run_e2e_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                            | resource    |
-| [aws_iam_role_policy.run_load_test_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                 | resource    |
-| [aws_iam_role_policy.run_preprod_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                   | resource    |
-| [aws_iam_role_policy.run_preprod_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                        | resource    |
-| [aws_iam_role_policy.run_production_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                | resource    |
-| [aws_iam_role_policy.update_e2e_test_ssm_params](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                               | resource    |
-| [aws_iam_user_policy.allow_ci_cloudfront](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy)                                      | resource    |
-| [aws_iam_user_policy.allow_ci_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy)                                | resource    |
-| [aws_kms_alias.codepipeline_deploy_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias)                                              | resource    |
-| [aws_kms_key.codepipeline_deploy_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key)                                                  | resource    |
-| [aws_route53_record.bichard7_name_servers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                                      | resource    |
-| [aws_route53_record.bichard7_pathtolive_delegated_zone_validation_records](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)      | resource    |
-| [aws_route53_record.parent_zone_validation_records](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                             | resource    |
-| [aws_route53_zone.codebuild_public_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone)                                          | resource    |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                               | data source |
-| [aws_caller_identity.integration_baseline](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                  | data source |
-| [aws_caller_identity.integration_next](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                      | data source |
-| [aws_caller_identity.preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                               | data source |
-| [aws_caller_identity.production](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                            | data source |
-| [aws_ecr_repository.bichard](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository)                                                 | data source |
-| [aws_ecr_repository.codebuild_base](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository)                                          | data source |
-| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                                          | data source |
-| [external_external.latest_bichard_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external)                                      | data source |
-| [external_external.latest_codebuild_base](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external)                                     | data source |
-| [template_file.allow_codebuild_codestar_connection](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file)                               | data source |
-| [template_file.codepipeline_policy_template](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file)                                      | data source |
-| [template_file.kms_permissions](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file)                                                   | data source |
-| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state)                                    | data source |
+| Name | Type |
+|------|------|
+| [aws_acm_certificate.bichard7_pathtolive_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/acm_certificate) | resource |
+| [aws_acm_certificate_validation.base_infra_certificate_validation](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/acm_certificate_validation) | resource |
+| [aws_codebuild_webhook.e2e_tests_pr_webhook](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/codebuild_webhook) | resource |
+| [aws_codepipeline.path_to_live](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/codepipeline) | resource |
+| [aws_codestarconnections_connection.github](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/codestarconnections_connection) | resource |
+| [aws_iam_role.codepipeline_role](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_e2e_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_load_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_pre_prod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_production](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.allow_code_pipeline_connection_for_load_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.allow_code_pipeline_connection_for_production_smoketests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.allow_integration_baseline_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.allow_integration_next_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.allow_production_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.allow_qsolution_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.apply_dev_sg_to_e2e_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.apply_dev_sg_to_preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.code_to_be_deployed](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.codepipeline_policy](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.remove_dev_sg_from_e2e_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.remove_dev_sg_from_preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.restart_pnc_emulator_e2e_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.run_e2e_test_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.run_e2e_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.run_load_test_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.run_preprod_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.run_preprod_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.run_production_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.update_e2e_test_ssm_params](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_user_policy.allow_ci_cloudfront](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy) | resource |
+| [aws_iam_user_policy.allow_ci_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy) | resource |
+| [aws_kms_alias.codepipeline_deploy_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias) | resource |
+| [aws_kms_key.codepipeline_deploy_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key) | resource |
+| [aws_route53_record.bichard7_name_servers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
+| [aws_route53_record.bichard7_pathtolive_delegated_zone_validation_records](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
+| [aws_route53_record.parent_zone_validation_records](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
+| [aws_route53_zone.codebuild_public_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.integration_baseline](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.integration_next](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.production](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_ecr_repository.bichard](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository) | data source |
+| [aws_ecr_repository.codebuild_base](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository) | data source |
+| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
+| [external_external.latest_bichard_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
+| [external_external.latest_codebuild_base](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
+| [template_file.allow_codebuild_codestar_connection](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+| [template_file.codepipeline_policy_template](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+| [template_file.kms_permissions](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs
 
-| Name                                                                     | Description                               | Type     | Default | Required |
-| ------------------------------------------------------------------------ | ----------------------------------------- | -------- | ------- | :------: |
-| <a name="input_is_cd"></a> [is_cd](#input_is_cd)                         | Is this being run by CD                   | `bool`   | `false` |    no    |
-| <a name="input_slack_webhook"></a> [slack_webhook](#input_slack_webhook) | Our webhook for sending messages to slack | `string` | `""`    |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_is_cd"></a> [is\_cd](#input\_is\_cd) | Is this being run by CD | `bool` | `false` | no |
+| <a name="input_slack_webhook"></a> [slack\_webhook](#input\_slack\_webhook) | Our webhook for sending messages to slack | `string` | `""` | no |
 
 ## Outputs
 
-| Name                                                                                                                                                                       | Description                                                     |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| <a name="output_base_resources"></a> [base_resources](#output_base_resources)                                                                                              | The outputs for our base resources                              |
-| <a name="output_bichard_liberty_ecr"></a> [bichard_liberty_ecr](#output_bichard_liberty_ecr)                                                                               | The Bichard Liberty ecr repository details                      |
-| <a name="output_codebuild_cidr_block"></a> [codebuild_cidr_block](#output_codebuild_cidr_block)                                                                            | The cidr block for our codebuild vpc                            |
-| <a name="output_codebuild_private_cidr_blocks"></a> [codebuild_private_cidr_blocks](#output_codebuild_private_cidr_blocks)                                                 | A list of private cidr blocks                                   |
-| <a name="output_codebuild_private_subnet_ids"></a> [codebuild_private_subnet_ids](#output_codebuild_private_subnet_ids)                                                    | A list of all the subnet ids                                    |
-| <a name="output_codebuild_public_cidr_blocks"></a> [codebuild_public_cidr_blocks](#output_codebuild_public_cidr_blocks)                                                    | A list of private cidr blocks                                   |
-| <a name="output_codebuild_public_subnet_ids"></a> [codebuild_public_subnet_ids](#output_codebuild_public_subnet_ids)                                                       | A list of public subnet ids                                     |
-| <a name="output_codebuild_security_group_id"></a> [codebuild_security_group_id](#output_codebuild_security_group_id)                                                       | The VPC security group id used by codebuild                     |
-| <a name="output_codebuild_subnet_ids"></a> [codebuild_subnet_ids](#output_codebuild_subnet_ids)                                                                            | A list of all the subnet ids                                    |
-| <a name="output_codebuild_vpc_id"></a> [codebuild_vpc_id](#output_codebuild_vpc_id)                                                                                        | The vpc ID for our codebuild vpc                                |
-| <a name="output_codebuild_zone_id"></a> [codebuild_zone_id](#output_codebuild_zone_id)                                                                                     | The public zone id for our codebuild VPC route53 zone           |
-| <a name="output_codepipeline_bucket"></a> [codepipeline_bucket](#output_codepipeline_bucket)                                                                               | The name of the codebuild/pipeline bucket                       |
-| <a name="output_prometheus_cloudwatch_exporter_repository_arn"></a> [prometheus_cloudwatch_exporter_repository_arn](#output_prometheus_cloudwatch_exporter_repository_arn) | The repository arn for our prometheus cloudwatch exporter image |
-| <a name="output_prometheus_cloudwatch_exporter_repository_url"></a> [prometheus_cloudwatch_exporter_repository_url](#output_prometheus_cloudwatch_exporter_repository_url) | The repository url for our prometheus cloudwatch exporter image |
-| <a name="output_prometheus_repository_arn"></a> [prometheus_repository_arn](#output_prometheus_repository_arn)                                                             | The repository arn for our prometheus image                     |
-| <a name="output_prometheus_repository_url"></a> [prometheus_repository_url](#output_prometheus_repository_url)                                                             | The repository url for our prometheus image                     |
-| <a name="output_scanning_portal_fqdn"></a> [scanning_portal_fqdn](#output_scanning_portal_fqdn)                                                                            | The external fqdn of our scanning portal                        |
-| <a name="output_ssl_certificate_arn"></a> [ssl_certificate_arn](#output_ssl_certificate_arn)                                                                               | The arn for our ACM ssl certificate                             |
-| <a name="output_staged_docker_resources"></a> [staged_docker_resources](#output_staged_docker_resources)                                                                   | The outputs from our staged docker images module                |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_base_resources"></a> [base\_resources](#output\_base\_resources) | The outputs for our base resources |
+| <a name="output_bichard_liberty_ecr"></a> [bichard\_liberty\_ecr](#output\_bichard\_liberty\_ecr) | The Bichard Liberty ecr repository details |
+| <a name="output_codebuild_cidr_block"></a> [codebuild\_cidr\_block](#output\_codebuild\_cidr\_block) | The cidr block for our codebuild vpc |
+| <a name="output_codebuild_private_cidr_blocks"></a> [codebuild\_private\_cidr\_blocks](#output\_codebuild\_private\_cidr\_blocks) | A list of private cidr blocks |
+| <a name="output_codebuild_private_subnet_ids"></a> [codebuild\_private\_subnet\_ids](#output\_codebuild\_private\_subnet\_ids) | A list of all the subnet ids |
+| <a name="output_codebuild_public_cidr_blocks"></a> [codebuild\_public\_cidr\_blocks](#output\_codebuild\_public\_cidr\_blocks) | A list of private cidr blocks |
+| <a name="output_codebuild_public_subnet_ids"></a> [codebuild\_public\_subnet\_ids](#output\_codebuild\_public\_subnet\_ids) | A list of public subnet ids |
+| <a name="output_codebuild_security_group_id"></a> [codebuild\_security\_group\_id](#output\_codebuild\_security\_group\_id) | The VPC security group id used by codebuild |
+| <a name="output_codebuild_subnet_ids"></a> [codebuild\_subnet\_ids](#output\_codebuild\_subnet\_ids) | A list of all the subnet ids |
+| <a name="output_codebuild_vpc_id"></a> [codebuild\_vpc\_id](#output\_codebuild\_vpc\_id) | The vpc ID for our codebuild vpc |
+| <a name="output_codebuild_zone_id"></a> [codebuild\_zone\_id](#output\_codebuild\_zone\_id) | The public zone id for our codebuild VPC route53 zone |
+| <a name="output_codepipeline_bucket"></a> [codepipeline\_bucket](#output\_codepipeline\_bucket) | The name of the codebuild/pipeline bucket |
+| <a name="output_prometheus_cloudwatch_exporter_repository_arn"></a> [prometheus\_cloudwatch\_exporter\_repository\_arn](#output\_prometheus\_cloudwatch\_exporter\_repository\_arn) | The repository arn for our prometheus cloudwatch exporter image |
+| <a name="output_prometheus_cloudwatch_exporter_repository_url"></a> [prometheus\_cloudwatch\_exporter\_repository\_url](#output\_prometheus\_cloudwatch\_exporter\_repository\_url) | The repository url for our prometheus cloudwatch exporter image |
+| <a name="output_prometheus_repository_arn"></a> [prometheus\_repository\_arn](#output\_prometheus\_repository\_arn) | The repository arn for our prometheus image |
+| <a name="output_prometheus_repository_url"></a> [prometheus\_repository\_url](#output\_prometheus\_repository\_url) | The repository url for our prometheus image |
+| <a name="output_scanning_portal_fqdn"></a> [scanning\_portal\_fqdn](#output\_scanning\_portal\_fqdn) | The external fqdn of our scanning portal |
+| <a name="output_ssl_certificate_arn"></a> [ssl\_certificate\_arn](#output\_ssl\_certificate\_arn) | The arn for our ACM ssl certificate |
+| <a name="output_staged_docker_resources"></a> [staged\_docker\_resources](#output\_staged\_docker\_resources) | The outputs from our staged docker images module |
 <!-- END_TF_DOCS -->

--- a/terraform/shared_account_pathtolive_infra_ci/README.md
+++ b/terraform/shared_account_pathtolive_infra_ci/README.md
@@ -3,177 +3,179 @@
 Creates various codebuild/codepipeline jobs and a codebuild vpc for our path to live account
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0.0 |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
+| <a name="requirement_local"></a> [local](#requirement_local)             | ~> 2.0.0 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_aws.integration_baseline"></a> [aws.integration\_baseline](#provider\_aws.integration\_baseline) | 3.75.2 |
-| <a name="provider_aws.integration_next"></a> [aws.integration\_next](#provider\_aws.integration\_next) | 3.75.2 |
-| <a name="provider_aws.production"></a> [aws.production](#provider\_aws.production) | 3.75.2 |
-| <a name="provider_aws.qsolution"></a> [aws.qsolution](#provider\_aws.qsolution) | 3.75.2 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.1.0 |
-| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
-| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+| Name                                                                                                            | Version |
+| --------------------------------------------------------------------------------------------------------------- | ------- |
+| <a name="provider_aws"></a> [aws](#provider_aws)                                                                | 3.75.2  |
+| <a name="provider_aws.integration_baseline"></a> [aws.integration_baseline](#provider_aws.integration_baseline) | 3.75.2  |
+| <a name="provider_aws.integration_next"></a> [aws.integration_next](#provider_aws.integration_next)             | 3.75.2  |
+| <a name="provider_aws.production"></a> [aws.production](#provider_aws.production)                               | 3.75.2  |
+| <a name="provider_aws.qsolution"></a> [aws.qsolution](#provider_aws.qsolution)                                  | 3.75.2  |
+| <a name="provider_external"></a> [external](#provider_external)                                                 | 2.1.0   |
+| <a name="provider_template"></a> [template](#provider_template)                                                 | 2.2.0   |
+| <a name="provider_terraform"></a> [terraform](#provider_terraform)                                              | n/a     |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_apply_dev_sg_to_e2e_test"></a> [apply\_dev\_sg\_to\_e2e\_test](#module\_apply\_dev\_sg\_to\_e2e\_test) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_apply_dev_sg_to_load_test"></a> [apply\_dev\_sg\_to\_load\_test](#module\_apply\_dev\_sg\_to\_load\_test) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_apply_dev_sg_to_preprod"></a> [apply\_dev\_sg\_to\_preprod](#module\_apply\_dev\_sg\_to\_preprod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_apply_dev_sg_to_prod"></a> [apply\_dev\_sg\_to\_prod](#module\_apply\_dev\_sg\_to\_prod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_build_ci_monitoring"></a> [build\_ci\_monitoring](#module\_build\_ci\_monitoring) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_build_ci_monitoring_schedule"></a> [build\_ci\_monitoring\_schedule](#module\_build\_ci\_monitoring\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_build_nginx_scan_portal"></a> [build\_nginx\_scan\_portal](#module\_build\_nginx\_scan\_portal) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_code_to_be_deployed"></a> [code\_to\_be\_deployed](#module\_code\_to\_be\_deployed) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_codebuild_base_resources"></a> [codebuild\_base\_resources](#module\_codebuild\_base\_resources) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_base_resources | n/a |
-| <a name="module_codebuild_docker_resources"></a> [codebuild\_docker\_resources](#module\_codebuild\_docker\_resources) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/aws_ecr_repositories | n/a |
-| <a name="module_common_build_jobs"></a> [common\_build\_jobs](#module\_common\_build\_jobs) | ../modules/shared_cd_common_jobs | n/a |
-| <a name="module_deploy_e2e_test_terraform"></a> [deploy\_e2e\_test\_terraform](#module\_deploy\_e2e\_test\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_deploy_load_test_terraform"></a> [deploy\_load\_test\_terraform](#module\_deploy\_load\_test\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_deploy_preprod_terraform"></a> [deploy\_preprod\_terraform](#module\_deploy\_preprod\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_deploy_production_terraform"></a> [deploy\_production\_terraform](#module\_deploy\_production\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_destroy_e2e_test_terraform"></a> [destroy\_e2e\_test\_terraform](#module\_destroy\_e2e\_test\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_destroy_load_test_terraform"></a> [destroy\_load\_test\_terraform](#module\_destroy\_load\_test\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_destroy_preprod_terraform"></a> [destroy\_preprod\_terraform](#module\_destroy\_preprod\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_destroy_production_terraform"></a> [destroy\_production\_terraform](#module\_destroy\_production\_terraform) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_disable_maintenance_page_preprod"></a> [disable\_maintenance\_page\_preprod](#module\_disable\_maintenance\_page\_preprod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_disable_maintenance_page_prod"></a> [disable\_maintenance\_page\_prod](#module\_disable\_maintenance\_page\_prod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_ecs_scanning_portal"></a> [ecs\_scanning\_portal](#module\_ecs\_scanning\_portal) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules//scanning_results_ecs | n/a |
-| <a name="module_enable_maintenance_page_preprod"></a> [enable\_maintenance\_page\_preprod](#module\_enable\_maintenance\_page\_preprod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_enable_maintenance_page_prod"></a> [enable\_maintenance\_page\_prod](#module\_enable\_maintenance\_page\_prod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_notify_pipeline"></a> [notify\_pipeline](#module\_notify\_pipeline) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codestar_notification | n/a |
-| <a name="module_owasp_scan_e2e_test"></a> [owasp\_scan\_e2e\_test](#module\_owasp\_scan\_e2e\_test) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_owasp_scan_e2e_test_audit_logging"></a> [owasp\_scan\_e2e\_test\_audit\_logging](#module\_owasp\_scan\_e2e\_test\_audit\_logging) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_owasp_scan_e2e_test_audit_logging_trigger"></a> [owasp\_scan\_e2e\_test\_audit\_logging\_trigger](#module\_owasp\_scan\_e2e\_test\_audit\_logging\_trigger) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_owasp_scan_e2e_test_trigger"></a> [owasp\_scan\_e2e\_test\_trigger](#module\_owasp\_scan\_e2e\_test\_trigger) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_owasp_scan_e2e_test_user_service"></a> [owasp\_scan\_e2e\_test\_user\_service](#module\_owasp\_scan\_e2e\_test\_user\_service) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_owasp_scan_e2e_test_user_service_trigger"></a> [owasp\_scan\_e2e\_test\_user\_service\_trigger](#module\_owasp\_scan\_e2e\_test\_user\_service\_trigger) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_remove_dev_sg_from_e2e_test"></a> [remove\_dev\_sg\_from\_e2e\_test](#module\_remove\_dev\_sg\_from\_e2e\_test) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_remove_dev_sg_from_e2e_test_schedule"></a> [remove\_dev\_sg\_from\_e2e\_test\_schedule](#module\_remove\_dev\_sg\_from\_e2e\_test\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_remove_dev_sg_from_load_test"></a> [remove\_dev\_sg\_from\_load\_test](#module\_remove\_dev\_sg\_from\_load\_test) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_remove_dev_sg_from_preprod"></a> [remove\_dev\_sg\_from\_preprod](#module\_remove\_dev\_sg\_from\_preprod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_remove_dev_sg_from_preprod_schedule"></a> [remove\_dev\_sg\_from\_preprod\_schedule](#module\_remove\_dev\_sg\_from\_preprod\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_remove_dev_sg_from_prod"></a> [remove\_dev\_sg\_from\_prod](#module\_remove\_dev\_sg\_from\_prod) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_remove_dev_sg_from_prod_schedule"></a> [remove\_dev\_sg\_from\_prod\_schedule](#module\_remove\_dev\_sg\_from\_prod\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_run_destroy_load_test_env_schedule"></a> [run\_destroy\_load\_test\_env\_schedule](#module\_run\_destroy\_load\_test\_env\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_run_e2e_test_migrations"></a> [run\_e2e\_test\_migrations](#module\_run\_e2e\_test\_migrations) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_run_e2e_tests"></a> [run\_e2e\_tests](#module\_run\_e2e\_tests) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_run_e2e_tests_restart_pnc_container"></a> [run\_e2e\_tests\_restart\_pnc\_container](#module\_run\_e2e\_tests\_restart\_pnc\_container) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_run_e2e_tests_schedule"></a> [run\_e2e\_tests\_schedule](#module\_run\_e2e\_tests\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_run_load_test_migrations"></a> [run\_load\_test\_migrations](#module\_run\_load\_test\_migrations) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_run_load_tests"></a> [run\_load\_tests](#module\_run\_load\_tests) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_run_load_tests_terminate_pnc_container"></a> [run\_load\_tests\_terminate\_pnc\_container](#module\_run\_load\_tests\_terminate\_pnc\_container) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_run_preprod_migrations"></a> [run\_preprod\_migrations](#module\_run\_preprod\_migrations) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_run_preprod_tests"></a> [run\_preprod\_tests](#module\_run\_preprod\_tests) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_run_prod_smoketests"></a> [run\_prod\_smoketests](#module\_run\_prod\_smoketests) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_run_production_migrations"></a> [run\_production\_migrations](#module\_run\_production\_migrations) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_scoutsuite_scan_integration_baseline"></a> [scoutsuite\_scan\_integration\_baseline](#module\_scoutsuite\_scan\_integration\_baseline) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_scoutsuite_scan_integration_baseline_schedule"></a> [scoutsuite\_scan\_integration\_baseline\_schedule](#module\_scoutsuite\_scan\_integration\_baseline\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_scoutsuite_scan_integration_next"></a> [scoutsuite\_scan\_integration\_next](#module\_scoutsuite\_scan\_integration\_next) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_scoutsuite_scan_integration_next_schedule"></a> [scoutsuite\_scan\_integration\_next\_schedule](#module\_scoutsuite\_scan\_integration\_next\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_scoutsuite_scan_shared"></a> [scoutsuite\_scan\_shared](#module\_scoutsuite\_scan\_shared) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_scoutsuite_scan_shared_schedule"></a> [scoutsuite\_scan\_shared\_schedule](#module\_scoutsuite\_scan\_shared\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_self_signed_certificate"></a> [self\_signed\_certificate](#module\_self\_signed\_certificate) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/self_signed_certificate | n/a |
-| <a name="module_tag_vars"></a> [tag\_vars](#module\_tag\_vars) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars | n/a |
-| <a name="module_update_environment_ssm_params"></a> [update\_environment\_ssm\_params](#module\_update\_environment\_ssm\_params) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| Name                                                                                                                                                                       | Source                                                                                                  | Version |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------- |
+| <a name="module_apply_dev_sg_to_e2e_test"></a> [apply_dev_sg_to_e2e_test](#module_apply_dev_sg_to_e2e_test)                                                                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_apply_dev_sg_to_load_test"></a> [apply_dev_sg_to_load_test](#module_apply_dev_sg_to_load_test)                                                             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_apply_dev_sg_to_preprod"></a> [apply_dev_sg_to_preprod](#module_apply_dev_sg_to_preprod)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_apply_dev_sg_to_prod"></a> [apply_dev_sg_to_prod](#module_apply_dev_sg_to_prod)                                                                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_build_ci_monitoring"></a> [build_ci_monitoring](#module_build_ci_monitoring)                                                                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_build_ci_monitoring_schedule"></a> [build_ci_monitoring_schedule](#module_build_ci_monitoring_schedule)                                                    | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_build_nginx_scan_portal"></a> [build_nginx_scan_portal](#module_build_nginx_scan_portal)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_code_to_be_deployed"></a> [code_to_be_deployed](#module_code_to_be_deployed)                                                                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_codebuild_base_resources"></a> [codebuild_base_resources](#module_codebuild_base_resources)                                                                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_base_resources | n/a     |
+| <a name="module_codebuild_docker_resources"></a> [codebuild_docker_resources](#module_codebuild_docker_resources)                                                          | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/aws_ecr_repositories     | n/a     |
+| <a name="module_common_build_jobs"></a> [common_build_jobs](#module_common_build_jobs)                                                                                     | ../modules/shared_cd_common_jobs                                                                        | n/a     |
+| <a name="module_deploy_e2e_test_terraform"></a> [deploy_e2e_test_terraform](#module_deploy_e2e_test_terraform)                                                             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_deploy_load_test_terraform"></a> [deploy_load_test_terraform](#module_deploy_load_test_terraform)                                                          | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_deploy_preprod_terraform"></a> [deploy_preprod_terraform](#module_deploy_preprod_terraform)                                                                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_deploy_production_terraform"></a> [deploy_production_terraform](#module_deploy_production_terraform)                                                       | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_destroy_e2e_test_terraform"></a> [destroy_e2e_test_terraform](#module_destroy_e2e_test_terraform)                                                          | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_destroy_load_test_terraform"></a> [destroy_load_test_terraform](#module_destroy_load_test_terraform)                                                       | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_destroy_preprod_terraform"></a> [destroy_preprod_terraform](#module_destroy_preprod_terraform)                                                             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_destroy_production_terraform"></a> [destroy_production_terraform](#module_destroy_production_terraform)                                                    | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_disable_maintenance_page_preprod"></a> [disable_maintenance_page_preprod](#module_disable_maintenance_page_preprod)                                        | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_disable_maintenance_page_prod"></a> [disable_maintenance_page_prod](#module_disable_maintenance_page_prod)                                                 | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_ecs_scanning_portal"></a> [ecs_scanning_portal](#module_ecs_scanning_portal)                                                                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules//scanning_results_ecs    | n/a     |
+| <a name="module_enable_maintenance_page_preprod"></a> [enable_maintenance_page_preprod](#module_enable_maintenance_page_preprod)                                           | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_enable_maintenance_page_prod"></a> [enable_maintenance_page_prod](#module_enable_maintenance_page_prod)                                                    | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_label"></a> [label](#module_label)                                                                                                                         | cloudposse/label/null                                                                                   | 0.24.1  |
+| <a name="module_notify_pipeline"></a> [notify_pipeline](#module_notify_pipeline)                                                                                           | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codestar_notification    | n/a     |
+| <a name="module_owasp_scan_e2e_test"></a> [owasp_scan_e2e_test](#module_owasp_scan_e2e_test)                                                                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_owasp_scan_e2e_test_audit_logging"></a> [owasp_scan_e2e_test_audit_logging](#module_owasp_scan_e2e_test_audit_logging)                                     | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_owasp_scan_e2e_test_audit_logging_trigger"></a> [owasp_scan_e2e_test_audit_logging_trigger](#module_owasp_scan_e2e_test_audit_logging_trigger)             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_owasp_scan_e2e_test_trigger"></a> [owasp_scan_e2e_test_trigger](#module_owasp_scan_e2e_test_trigger)                                                       | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_owasp_scan_e2e_test_user_service"></a> [owasp_scan_e2e_test_user_service](#module_owasp_scan_e2e_test_user_service)                                        | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_owasp_scan_e2e_test_user_service_trigger"></a> [owasp_scan_e2e_test_user_service_trigger](#module_owasp_scan_e2e_test_user_service_trigger)                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_remove_dev_sg_from_e2e_test"></a> [remove_dev_sg_from_e2e_test](#module_remove_dev_sg_from_e2e_test)                                                       | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_remove_dev_sg_from_e2e_test_schedule"></a> [remove_dev_sg_from_e2e_test_schedule](#module_remove_dev_sg_from_e2e_test_schedule)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_remove_dev_sg_from_load_test"></a> [remove_dev_sg_from_load_test](#module_remove_dev_sg_from_load_test)                                                    | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_remove_dev_sg_from_preprod"></a> [remove_dev_sg_from_preprod](#module_remove_dev_sg_from_preprod)                                                          | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_remove_dev_sg_from_preprod_schedule"></a> [remove_dev_sg_from_preprod_schedule](#module_remove_dev_sg_from_preprod_schedule)                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_remove_dev_sg_from_prod"></a> [remove_dev_sg_from_prod](#module_remove_dev_sg_from_prod)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_remove_dev_sg_from_prod_schedule"></a> [remove_dev_sg_from_prod_schedule](#module_remove_dev_sg_from_prod_schedule)                                        | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_run_destroy_load_test_env_schedule"></a> [run_destroy_load_test_env_schedule](#module_run_destroy_load_test_env_schedule)                                  | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_run_e2e_test_migrations"></a> [run_e2e_test_migrations](#module_run_e2e_test_migrations)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_run_e2e_tests"></a> [run_e2e_tests](#module_run_e2e_tests)                                                                                                 | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_run_e2e_tests_restart_pnc_container"></a> [run_e2e_tests_restart_pnc_container](#module_run_e2e_tests_restart_pnc_container)                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_run_e2e_tests_schedule"></a> [run_e2e_tests_schedule](#module_run_e2e_tests_schedule)                                                                      | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_run_load_test_migrations"></a> [run_load_test_migrations](#module_run_load_test_migrations)                                                                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_run_load_tests"></a> [run_load_tests](#module_run_load_tests)                                                                                              | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_run_load_tests_terminate_pnc_container"></a> [run_load_tests_terminate_pnc_container](#module_run_load_tests_terminate_pnc_container)                      | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_run_preprod_migrations"></a> [run_preprod_migrations](#module_run_preprod_migrations)                                                                      | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_run_preprod_tests"></a> [run_preprod_tests](#module_run_preprod_tests)                                                                                     | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_run_prod_smoketests"></a> [run_prod_smoketests](#module_run_prod_smoketests)                                                                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_run_production_migrations"></a> [run_production_migrations](#module_run_production_migrations)                                                             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_scoutsuite_scan_integration_baseline"></a> [scoutsuite_scan_integration_baseline](#module_scoutsuite_scan_integration_baseline)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_scoutsuite_scan_integration_baseline_schedule"></a> [scoutsuite_scan_integration_baseline_schedule](#module_scoutsuite_scan_integration_baseline_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_scoutsuite_scan_integration_next"></a> [scoutsuite_scan_integration_next](#module_scoutsuite_scan_integration_next)                                        | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_scoutsuite_scan_integration_next_schedule"></a> [scoutsuite_scan_integration_next_schedule](#module_scoutsuite_scan_integration_next_schedule)             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_scoutsuite_scan_shared"></a> [scoutsuite_scan_shared](#module_scoutsuite_scan_shared)                                                                      | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_scoutsuite_scan_shared_schedule"></a> [scoutsuite_scan_shared_schedule](#module_scoutsuite_scan_shared_schedule)                                           | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_self_signed_certificate"></a> [self_signed_certificate](#module_self_signed_certificate)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/self_signed_certificate  | n/a     |
+| <a name="module_tag_vars"></a> [tag_vars](#module_tag_vars)                                                                                                                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars                 | n/a     |
+| <a name="module_update_environment_ssm_params"></a> [update_environment_ssm_params](#module_update_environment_ssm_params)                                                 | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_acm_certificate.bichard7_pathtolive_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/acm_certificate) | resource |
-| [aws_acm_certificate_validation.base_infra_certificate_validation](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/acm_certificate_validation) | resource |
-| [aws_codebuild_webhook.e2e_tests_pr_webhook](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/codebuild_webhook) | resource |
-| [aws_codepipeline.path_to_live](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/codepipeline) | resource |
-| [aws_codestarconnections_connection.github](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/codestarconnections_connection) | resource |
-| [aws_iam_role.codepipeline_role](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_e2e_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_load_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_pre_prod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_production](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.allow_code_pipeline_connection_for_load_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.allow_code_pipeline_connection_for_production_smoketests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.allow_integration_baseline_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.allow_integration_next_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.allow_production_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.allow_qsolution_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.apply_dev_sg_to_e2e_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.apply_dev_sg_to_preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.code_to_be_deployed](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.codepipeline_policy](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.remove_dev_sg_from_e2e_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.remove_dev_sg_from_preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.restart_pnc_emulator_e2e_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.run_e2e_test_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.run_e2e_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.run_load_test_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.run_preprod_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.run_preprod_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.run_production_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.update_e2e_test_ssm_params](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_user_policy.allow_ci_cloudfront](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy) | resource |
-| [aws_iam_user_policy.allow_ci_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy) | resource |
-| [aws_kms_alias.codepipeline_deploy_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias) | resource |
-| [aws_kms_key.codepipeline_deploy_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key) | resource |
-| [aws_route53_record.bichard7_name_servers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_route53_record.bichard7_pathtolive_delegated_zone_validation_records](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_route53_record.parent_zone_validation_records](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_route53_zone.codebuild_public_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.integration_baseline](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.integration_next](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.production](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_ecr_repository.bichard](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository) | data source |
-| [aws_ecr_repository.codebuild_base](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository) | data source |
-| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
-| [external_external.latest_bichard_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
-| [external_external.latest_codebuild_base](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
-| [template_file.allow_codebuild_codestar_connection](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
-| [template_file.codepipeline_policy_template](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
-| [template_file.kms_permissions](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
-| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| Name                                                                                                                                                                        | Type        |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_acm_certificate.bichard7_pathtolive_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/acm_certificate)                       | resource    |
+| [aws_acm_certificate_validation.base_infra_certificate_validation](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/acm_certificate_validation)  | resource    |
+| [aws_codebuild_webhook.e2e_tests_pr_webhook](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/codebuild_webhook)                                 | resource    |
+| [aws_codepipeline.path_to_live](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/codepipeline)                                                   | resource    |
+| [aws_codestarconnections_connection.github](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/codestarconnections_connection)                     | resource    |
+| [aws_iam_role.codepipeline_role](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role)                                                      | resource    |
+| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_e2e_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)       | resource    |
+| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_load_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)      | resource    |
+| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_pre_prod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)       | resource    |
+| [aws_iam_role_policy.allow_code_pipeline_connection_for_deploy_production](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)     | resource    |
+| [aws_iam_role_policy.allow_code_pipeline_connection_for_load_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)            | resource    |
+| [aws_iam_role_policy.allow_code_pipeline_connection_for_production_smoketests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource    |
+| [aws_iam_role_policy.allow_integration_baseline_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)              | resource    |
+| [aws_iam_role_policy.allow_integration_next_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                  | resource    |
+| [aws_iam_role_policy.allow_production_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                        | resource    |
+| [aws_iam_role_policy.allow_qsolution_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                         | resource    |
+| [aws_iam_role_policy.apply_dev_sg_to_e2e_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                 | resource    |
+| [aws_iam_role_policy.apply_dev_sg_to_preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                  | resource    |
+| [aws_iam_role_policy.code_to_be_deployed](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                      | resource    |
+| [aws_iam_role_policy.codepipeline_policy](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                      | resource    |
+| [aws_iam_role_policy.remove_dev_sg_from_e2e_test](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                              | resource    |
+| [aws_iam_role_policy.remove_dev_sg_from_preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                               | resource    |
+| [aws_iam_role_policy.restart_pnc_emulator_e2e_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                           | resource    |
+| [aws_iam_role_policy.run_e2e_test_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                  | resource    |
+| [aws_iam_role_policy.run_e2e_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                            | resource    |
+| [aws_iam_role_policy.run_load_test_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                 | resource    |
+| [aws_iam_role_policy.run_preprod_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                   | resource    |
+| [aws_iam_role_policy.run_preprod_tests](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                        | resource    |
+| [aws_iam_role_policy.run_production_migrations](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                | resource    |
+| [aws_iam_role_policy.update_e2e_test_ssm_params](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                               | resource    |
+| [aws_iam_user_policy.allow_ci_cloudfront](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy)                                      | resource    |
+| [aws_iam_user_policy.allow_ci_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy)                                | resource    |
+| [aws_kms_alias.codepipeline_deploy_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias)                                              | resource    |
+| [aws_kms_key.codepipeline_deploy_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key)                                                  | resource    |
+| [aws_route53_record.bichard7_name_servers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                                      | resource    |
+| [aws_route53_record.bichard7_pathtolive_delegated_zone_validation_records](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)      | resource    |
+| [aws_route53_record.parent_zone_validation_records](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                             | resource    |
+| [aws_route53_zone.codebuild_public_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone)                                          | resource    |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                               | data source |
+| [aws_caller_identity.integration_baseline](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                  | data source |
+| [aws_caller_identity.integration_next](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                      | data source |
+| [aws_caller_identity.preprod](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                               | data source |
+| [aws_caller_identity.production](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                            | data source |
+| [aws_ecr_repository.bichard](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository)                                                 | data source |
+| [aws_ecr_repository.codebuild_base](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository)                                          | data source |
+| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                                          | data source |
+| [external_external.latest_bichard_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external)                                      | data source |
+| [external_external.latest_codebuild_base](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external)                                     | data source |
+| [template_file.allow_codebuild_codestar_connection](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file)                               | data source |
+| [template_file.codepipeline_policy_template](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file)                                      | data source |
+| [template_file.kms_permissions](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file)                                                   | data source |
+| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state)                                    | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_is_cd"></a> [is\_cd](#input\_is\_cd) | Is this being run by CD | `bool` | `false` | no |
-| <a name="input_slack_webhook"></a> [slack\_webhook](#input\_slack\_webhook) | Our webhook for sending messages to slack | `string` | `""` | no |
+| Name                                                                     | Description                               | Type     | Default | Required |
+| ------------------------------------------------------------------------ | ----------------------------------------- | -------- | ------- | :------: |
+| <a name="input_is_cd"></a> [is_cd](#input_is_cd)                         | Is this being run by CD                   | `bool`   | `false` |    no    |
+| <a name="input_slack_webhook"></a> [slack_webhook](#input_slack_webhook) | Our webhook for sending messages to slack | `string` | `""`    |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_base_resources"></a> [base\_resources](#output\_base\_resources) | The outputs for our base resources |
-| <a name="output_bichard_liberty_ecr"></a> [bichard\_liberty\_ecr](#output\_bichard\_liberty\_ecr) | The Bichard Liberty ecr repository details |
-| <a name="output_codebuild_cidr_block"></a> [codebuild\_cidr\_block](#output\_codebuild\_cidr\_block) | The cidr block for our codebuild vpc |
-| <a name="output_codebuild_private_cidr_blocks"></a> [codebuild\_private\_cidr\_blocks](#output\_codebuild\_private\_cidr\_blocks) | A list of private cidr blocks |
-| <a name="output_codebuild_private_subnet_ids"></a> [codebuild\_private\_subnet\_ids](#output\_codebuild\_private\_subnet\_ids) | A list of all the subnet ids |
-| <a name="output_codebuild_public_cidr_blocks"></a> [codebuild\_public\_cidr\_blocks](#output\_codebuild\_public\_cidr\_blocks) | A list of private cidr blocks |
-| <a name="output_codebuild_public_subnet_ids"></a> [codebuild\_public\_subnet\_ids](#output\_codebuild\_public\_subnet\_ids) | A list of public subnet ids |
-| <a name="output_codebuild_security_group_id"></a> [codebuild\_security\_group\_id](#output\_codebuild\_security\_group\_id) | The VPC security group id used by codebuild |
-| <a name="output_codebuild_subnet_ids"></a> [codebuild\_subnet\_ids](#output\_codebuild\_subnet\_ids) | A list of all the subnet ids |
-| <a name="output_codebuild_vpc_id"></a> [codebuild\_vpc\_id](#output\_codebuild\_vpc\_id) | The vpc ID for our codebuild vpc |
-| <a name="output_codebuild_zone_id"></a> [codebuild\_zone\_id](#output\_codebuild\_zone\_id) | The public zone id for our codebuild VPC route53 zone |
-| <a name="output_codepipeline_bucket"></a> [codepipeline\_bucket](#output\_codepipeline\_bucket) | The name of the codebuild/pipeline bucket |
-| <a name="output_prometheus_cloudwatch_exporter_repository_arn"></a> [prometheus\_cloudwatch\_exporter\_repository\_arn](#output\_prometheus\_cloudwatch\_exporter\_repository\_arn) | The repository arn for our prometheus cloudwatch exporter image |
-| <a name="output_prometheus_cloudwatch_exporter_repository_url"></a> [prometheus\_cloudwatch\_exporter\_repository\_url](#output\_prometheus\_cloudwatch\_exporter\_repository\_url) | The repository url for our prometheus cloudwatch exporter image |
-| <a name="output_prometheus_repository_arn"></a> [prometheus\_repository\_arn](#output\_prometheus\_repository\_arn) | The repository arn for our prometheus image |
-| <a name="output_prometheus_repository_url"></a> [prometheus\_repository\_url](#output\_prometheus\_repository\_url) | The repository url for our prometheus image |
-| <a name="output_scanning_portal_fqdn"></a> [scanning\_portal\_fqdn](#output\_scanning\_portal\_fqdn) | The external fqdn of our scanning portal |
-| <a name="output_ssl_certificate_arn"></a> [ssl\_certificate\_arn](#output\_ssl\_certificate\_arn) | The arn for our ACM ssl certificate |
-| <a name="output_staged_docker_resources"></a> [staged\_docker\_resources](#output\_staged\_docker\_resources) | The outputs from our staged docker images module |
+| Name                                                                                                                                                                       | Description                                                     |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| <a name="output_base_resources"></a> [base_resources](#output_base_resources)                                                                                              | The outputs for our base resources                              |
+| <a name="output_bichard_liberty_ecr"></a> [bichard_liberty_ecr](#output_bichard_liberty_ecr)                                                                               | The Bichard Liberty ecr repository details                      |
+| <a name="output_codebuild_cidr_block"></a> [codebuild_cidr_block](#output_codebuild_cidr_block)                                                                            | The cidr block for our codebuild vpc                            |
+| <a name="output_codebuild_private_cidr_blocks"></a> [codebuild_private_cidr_blocks](#output_codebuild_private_cidr_blocks)                                                 | A list of private cidr blocks                                   |
+| <a name="output_codebuild_private_subnet_ids"></a> [codebuild_private_subnet_ids](#output_codebuild_private_subnet_ids)                                                    | A list of all the subnet ids                                    |
+| <a name="output_codebuild_public_cidr_blocks"></a> [codebuild_public_cidr_blocks](#output_codebuild_public_cidr_blocks)                                                    | A list of private cidr blocks                                   |
+| <a name="output_codebuild_public_subnet_ids"></a> [codebuild_public_subnet_ids](#output_codebuild_public_subnet_ids)                                                       | A list of public subnet ids                                     |
+| <a name="output_codebuild_security_group_id"></a> [codebuild_security_group_id](#output_codebuild_security_group_id)                                                       | The VPC security group id used by codebuild                     |
+| <a name="output_codebuild_subnet_ids"></a> [codebuild_subnet_ids](#output_codebuild_subnet_ids)                                                                            | A list of all the subnet ids                                    |
+| <a name="output_codebuild_vpc_id"></a> [codebuild_vpc_id](#output_codebuild_vpc_id)                                                                                        | The vpc ID for our codebuild vpc                                |
+| <a name="output_codebuild_zone_id"></a> [codebuild_zone_id](#output_codebuild_zone_id)                                                                                     | The public zone id for our codebuild VPC route53 zone           |
+| <a name="output_codepipeline_bucket"></a> [codepipeline_bucket](#output_codepipeline_bucket)                                                                               | The name of the codebuild/pipeline bucket                       |
+| <a name="output_prometheus_cloudwatch_exporter_repository_arn"></a> [prometheus_cloudwatch_exporter_repository_arn](#output_prometheus_cloudwatch_exporter_repository_arn) | The repository arn for our prometheus cloudwatch exporter image |
+| <a name="output_prometheus_cloudwatch_exporter_repository_url"></a> [prometheus_cloudwatch_exporter_repository_url](#output_prometheus_cloudwatch_exporter_repository_url) | The repository url for our prometheus cloudwatch exporter image |
+| <a name="output_prometheus_repository_arn"></a> [prometheus_repository_arn](#output_prometheus_repository_arn)                                                             | The repository arn for our prometheus image                     |
+| <a name="output_prometheus_repository_url"></a> [prometheus_repository_url](#output_prometheus_repository_url)                                                             | The repository url for our prometheus image                     |
+| <a name="output_scanning_portal_fqdn"></a> [scanning_portal_fqdn](#output_scanning_portal_fqdn)                                                                            | The external fqdn of our scanning portal                        |
+| <a name="output_ssl_certificate_arn"></a> [ssl_certificate_arn](#output_ssl_certificate_arn)                                                                               | The arn for our ACM ssl certificate                             |
+| <a name="output_staged_docker_resources"></a> [staged_docker_resources](#output_staged_docker_resources)                                                                   | The outputs from our staged docker images module                |
+
 <!-- END_TF_DOCS -->

--- a/terraform/shared_account_pathtolive_infra_ci/build_production.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_production.tf
@@ -102,10 +102,6 @@ module "deploy_production_terraform" {
       value = true
     },
     {
-      name  = "TF_VAR_is_production"
-      value = true
-    },
-    {
       name  = "TF_VAR_pnc_ip"
       value = "172.31.4.204"
     },

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -210,6 +210,10 @@ resource "aws_codepipeline" "path_to_live" {
             {
               name  = "TF_VAR_ui_deploy_tag"
               value = "#{HASHES.UI_IMAGE_HASH}"
+            },
+            {
+              name  = "INFRA_MODULES_COMMIT_HASH",
+              value = "#{HASHES.INFRA_MODULES_COMMIT_HASH}"
             }
           ]
         )
@@ -380,6 +384,10 @@ resource "aws_codepipeline" "path_to_live" {
             {
               name  = "TF_VAR_ui_deploy_tag"
               value = "#{HASHES.UI_IMAGE_HASH}"
+            },
+            {
+              name  = "INFRA_MODULES_COMMIT_HASH",
+              value = "#{HASHES.INFRA_MODULES_COMMIT_HASH}"
             }
           ]
         )
@@ -600,6 +608,10 @@ resource "aws_codepipeline" "path_to_live" {
             {
               name  = "TF_VAR_ui_deploy_tag"
               value = "#{HASHES.UI_IMAGE_HASH}"
+            },
+            {
+              name  = "INFRA_MODULES_COMMIT_HASH",
+              value = "#{HASHES.INFRA_MODULES_COMMIT_HASH}"
             }
           ]
         )

--- a/terraform/shared_account_pathtolive_infra_ci_monitoring/README.md
+++ b/terraform/shared_account_pathtolive_infra_ci_monitoring/README.md
@@ -3,54 +3,53 @@
 Creates a Grafana ECS cluster that pulls metrics from Cloudwatch
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version  |
-| ------------------------------------------------------------------------ | -------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
-| <a name="requirement_local"></a> [local](#requirement_local)             | = 2.0.0  |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | = 2.0.0 |
 
 ## Providers
 
-| Name                                                               | Version  |
-| ------------------------------------------------------------------ | -------- |
-| <a name="provider_archive"></a> [archive](#provider_archive)       | n/a      |
-| <a name="provider_aws"></a> [aws](#provider_aws)                   | = 3.75.2 |
-| <a name="provider_external"></a> [external](#provider_external)    | n/a      |
-| <a name="provider_terraform"></a> [terraform](#provider_terraform) | n/a      |
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.2.2 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
-| Name                                                                                            | Source                                                                                              | Version |
-| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------- |
-| <a name="module_codebuild_monitoring"></a> [codebuild_monitoring](#module_codebuild_monitoring) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_monitoring | n/a     |
-| <a name="module_label"></a> [label](#module_label)                                              | cloudposse/label/null                                                                               | 0.24.1  |
-| <a name="module_lambda_slack_webhook"></a> [lambda_slack_webhook](#module_lambda_slack_webhook) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_slack_webhook | n/a     |
-| <a name="module_tag_vars"></a> [tag_vars](#module_tag_vars)                                     | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars             | n/a     |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_codebuild_monitoring"></a> [codebuild\_monitoring](#module\_codebuild\_monitoring) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_monitoring | n/a |
+| <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_lambda_slack_webhook"></a> [lambda\_slack\_webhook](#module\_lambda\_slack\_webhook) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_slack_webhook | n/a |
+| <a name="module_tag_vars"></a> [tag\_vars](#module\_tag\_vars) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars | n/a |
 
 ## Resources
 
-| Name                                                                                                                                                             | Type        |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [aws_cloudwatch_event_rule.query_ecr_images_cron_schedule](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_rule)    | resource    |
-| [aws_cloudwatch_event_target.query_ecr_images_every_hour](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_target)   | resource    |
-| [aws_cloudwatch_metric_alarm.query_ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm)         | resource    |
-| [aws_iam_policy.lambda_allow_to_list_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)                             | resource    |
-| [aws_iam_policy.lambda_num_of_repos_manage_ec2_network_interfaces](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)       | resource    |
-| [aws_iam_role.ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role)                                             | resource    |
-| [aws_lambda_function.query_images_fn](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function)                               | resource    |
-| [aws_lambda_permission.allow_cloudwatch_to_invoke_query_ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission) | resource    |
-| [aws_security_group.slack_lambda_access_to_internet](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group)                 | resource    |
-| [aws_security_group_rule.resource_to_internet_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)           | resource    |
-| [archive_file.query_num_ecr_images](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file)                                     | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                    | data source |
-| [aws_ecr_repository.grafana_codebuild](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository)                            | data source |
-| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                               | data source |
-| [external_external.latest_grafana_codebuild_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external)                 | data source |
-| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state)                         | data source |
-| [terraform_remote_state.shared_infra_ci](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state)                      | data source |
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_event_rule.query_ecr_images_cron_schedule](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.query_ecr_images_every_hour](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_metric_alarm.query_ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_iam_policy.lambda_allow_to_list_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.lambda_num_of_repos_manage_ec2_network_interfaces](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
+| [aws_iam_role.ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role) | resource |
+| [aws_lambda_function.query_images_fn](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.allow_cloudwatch_to_invoke_query_ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission) | resource |
+| [aws_security_group.slack_lambda_access_to_internet](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group) | resource |
+| [aws_security_group_rule.resource_to_internet_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
+| [archive_file.query_num_ecr_images](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_ecr_repository.grafana_codebuild](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository) | data source |
+| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
+| [external_external.latest_grafana_codebuild_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
+| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.shared_infra_ci](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs
 
@@ -58,8 +57,7 @@ No inputs.
 
 ## Outputs
 
-| Name                                                                 | Description                   |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <a name="output_grafana_url"></a> [grafana_url](#output_grafana_url) | The url of our grafana server |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_grafana_url"></a> [grafana\_url](#output\_grafana\_url) | The url of our grafana server |
 <!-- END_TF_DOCS -->

--- a/terraform/shared_account_pathtolive_infra_ci_monitoring/README.md
+++ b/terraform/shared_account_pathtolive_infra_ci_monitoring/README.md
@@ -3,53 +3,54 @@
 Creates a Grafana ECS cluster that pulls metrics from Cloudwatch
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | = 2.0.0 |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
+| <a name="requirement_local"></a> [local](#requirement_local)             | = 2.0.0  |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.2.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.2.2 |
-| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+| Name                                                               | Version |
+| ------------------------------------------------------------------ | ------- |
+| <a name="provider_archive"></a> [archive](#provider_archive)       | 2.2.0   |
+| <a name="provider_aws"></a> [aws](#provider_aws)                   | 3.75.2  |
+| <a name="provider_external"></a> [external](#provider_external)    | 2.2.2   |
+| <a name="provider_terraform"></a> [terraform](#provider_terraform) | n/a     |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_codebuild_monitoring"></a> [codebuild\_monitoring](#module\_codebuild\_monitoring) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_monitoring | n/a |
-| <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_lambda_slack_webhook"></a> [lambda\_slack\_webhook](#module\_lambda\_slack\_webhook) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_slack_webhook | n/a |
-| <a name="module_tag_vars"></a> [tag\_vars](#module\_tag\_vars) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars | n/a |
+| Name                                                                                            | Source                                                                                              | Version |
+| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------- |
+| <a name="module_codebuild_monitoring"></a> [codebuild_monitoring](#module_codebuild_monitoring) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_monitoring | n/a     |
+| <a name="module_label"></a> [label](#module_label)                                              | cloudposse/label/null                                                                               | 0.24.1  |
+| <a name="module_lambda_slack_webhook"></a> [lambda_slack_webhook](#module_lambda_slack_webhook) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/lambda_slack_webhook | n/a     |
+| <a name="module_tag_vars"></a> [tag_vars](#module_tag_vars)                                     | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars             | n/a     |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_cloudwatch_event_rule.query_ecr_images_cron_schedule](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_target.query_ecr_images_every_hour](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_target) | resource |
-| [aws_cloudwatch_metric_alarm.query_ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm) | resource |
-| [aws_iam_policy.lambda_allow_to_list_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.lambda_num_of_repos_manage_ec2_network_interfaces](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
-| [aws_iam_role.ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role) | resource |
-| [aws_lambda_function.query_images_fn](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function) | resource |
-| [aws_lambda_permission.allow_cloudwatch_to_invoke_query_ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission) | resource |
-| [aws_security_group.slack_lambda_access_to_internet](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group) | resource |
-| [aws_security_group_rule.resource_to_internet_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [archive_file.query_num_ecr_images](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_ecr_repository.grafana_codebuild](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository) | data source |
-| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
-| [external_external.latest_grafana_codebuild_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
-| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.shared_infra_ci](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| Name                                                                                                                                                             | Type        |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_cloudwatch_event_rule.query_ecr_images_cron_schedule](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_rule)    | resource    |
+| [aws_cloudwatch_event_target.query_ecr_images_every_hour](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_target)   | resource    |
+| [aws_cloudwatch_metric_alarm.query_ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm)         | resource    |
+| [aws_iam_policy.lambda_allow_to_list_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)                             | resource    |
+| [aws_iam_policy.lambda_num_of_repos_manage_ec2_network_interfaces](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)       | resource    |
+| [aws_iam_role.ecr_repo_images](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role)                                             | resource    |
+| [aws_lambda_function.query_images_fn](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function)                               | resource    |
+| [aws_lambda_permission.allow_cloudwatch_to_invoke_query_ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission) | resource    |
+| [aws_security_group.slack_lambda_access_to_internet](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group)                 | resource    |
+| [aws_security_group_rule.resource_to_internet_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)           | resource    |
+| [archive_file.query_num_ecr_images](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file)                                     | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                    | data source |
+| [aws_ecr_repository.grafana_codebuild](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository)                            | data source |
+| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                               | data source |
+| [external_external.latest_grafana_codebuild_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external)                 | data source |
+| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state)                         | data source |
+| [terraform_remote_state.shared_infra_ci](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state)                      | data source |
 
 ## Inputs
 
@@ -57,7 +58,8 @@ No inputs.
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_grafana_url"></a> [grafana\_url](#output\_grafana\_url) | The url of our grafana server |
+| Name                                                                 | Description                   |
+| -------------------------------------------------------------------- | ----------------------------- |
+| <a name="output_grafana_url"></a> [grafana_url](#output_grafana_url) | The url of our grafana server |
+
 <!-- END_TF_DOCS -->

--- a/terraform/shared_account_sandbox_infra/README.md
+++ b/terraform/shared_account_sandbox_infra/README.md
@@ -24,93 +24,95 @@ export TF_VAR_sandbox_c_secret_key=""
 ```
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | ~> 2.2.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.1.0 |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
+| <a name="requirement_local"></a> [local](#requirement_local)             | ~> 2.0.0 |
+| <a name="requirement_null"></a> [null](#requirement_null)                | ~> 3.0.0 |
+| <a name="requirement_template"></a> [template](#requirement_template)    | ~> 2.2.0 |
+| <a name="requirement_tls"></a> [tls](#requirement_tls)                   | ~> 3.1.0 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_aws.sandbox_a"></a> [aws.sandbox\_a](#provider\_aws.sandbox\_a) | 3.75.2 |
-| <a name="provider_aws.sandbox_b"></a> [aws.sandbox\_b](#provider\_aws.sandbox\_b) | 3.75.2 |
-| <a name="provider_aws.sandbox_c"></a> [aws.sandbox\_c](#provider\_aws.sandbox\_c) | 3.75.2 |
-| <a name="provider_aws.sandbox_shared"></a> [aws.sandbox\_shared](#provider\_aws.sandbox\_shared) | 3.75.2 |
-| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
+| Name                                                                                          | Version |
+| --------------------------------------------------------------------------------------------- | ------- |
+| <a name="provider_aws"></a> [aws](#provider_aws)                                              | 3.75.2  |
+| <a name="provider_aws.sandbox_a"></a> [aws.sandbox_a](#provider_aws.sandbox_a)                | 3.75.2  |
+| <a name="provider_aws.sandbox_b"></a> [aws.sandbox_b](#provider_aws.sandbox_b)                | 3.75.2  |
+| <a name="provider_aws.sandbox_c"></a> [aws.sandbox_c](#provider_aws.sandbox_c)                | 3.75.2  |
+| <a name="provider_aws.sandbox_shared"></a> [aws.sandbox_shared](#provider_aws.sandbox_shared) | 3.75.2  |
+| <a name="provider_template"></a> [template](#provider_template)                               | 2.2.0   |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_aws_logs"></a> [aws\_logs](#module\_aws\_logs) | trussworks/logs/aws | ~> 10.3.0  |
-| <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_sandbox_a_child_access"></a> [sandbox\_a\_child\_access](#module\_sandbox\_a\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
-| <a name="module_sandbox_b_child_access"></a> [sandbox\_b\_child\_access](#module\_sandbox\_b\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
-| <a name="module_sandbox_c_child_access"></a> [sandbox\_c\_child\_access](#module\_sandbox\_c\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
-| <a name="module_shared_account_access_sandbox_a"></a> [shared\_account\_access\_sandbox\_a](#module\_shared\_account\_access\_sandbox\_a) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
-| <a name="module_shared_account_access_sandbox_b"></a> [shared\_account\_access\_sandbox\_b](#module\_shared\_account\_access\_sandbox\_b) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
-| <a name="module_shared_account_access_sandbox_c"></a> [shared\_account\_access\_sandbox\_c](#module\_shared\_account\_access\_sandbox\_c) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
-| <a name="module_shared_account_user_access"></a> [shared\_account\_user\_access](#module\_shared\_account\_user\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent | n/a |
-| <a name="module_tag_vars"></a> [tag\_vars](#module\_tag\_vars) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars | n/a |
+| Name                                                                                                                             | Source                                                                                                      | Version   |
+| -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | --------- |
+| <a name="module_aws_logs"></a> [aws_logs](#module_aws_logs)                                                                      | trussworks/logs/aws                                                                                         | ~> 10.3.0 |
+| <a name="module_label"></a> [label](#module_label)                                                                               | cloudposse/label/null                                                                                       | 0.24.1    |
+| <a name="module_sandbox_a_child_access"></a> [sandbox_a_child_access](#module_sandbox_a_child_access)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
+| <a name="module_sandbox_b_child_access"></a> [sandbox_b_child_access](#module_sandbox_b_child_access)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
+| <a name="module_sandbox_c_child_access"></a> [sandbox_c_child_access](#module_sandbox_c_child_access)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
+| <a name="module_shared_account_access_sandbox_a"></a> [shared_account_access_sandbox_a](#module_shared_account_access_sandbox_a) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
+| <a name="module_shared_account_access_sandbox_b"></a> [shared_account_access_sandbox_b](#module_shared_account_access_sandbox_b) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
+| <a name="module_shared_account_access_sandbox_c"></a> [shared_account_access_sandbox_c](#module_shared_account_access_sandbox_c) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
+| <a name="module_shared_account_user_access"></a> [shared_account_user_access](#module_shared_account_user_access)                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent        | n/a       |
+| <a name="module_tag_vars"></a> [tag_vars](#module_tag_vars)                                                                      | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars                     | n/a       |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_iam_policy.allow_route53](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
-| [aws_iam_role.allow_pathtolive_assume](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.allow_pathtolive_assume_route53](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_route53_record.bichard7_dev_name_servers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_route53_zone.bichard7_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone) | resource |
-| [aws_route53_zone.bichard7_dev_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.sandbox_a](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.sandbox_b](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.sandbox_c](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
-| [template_file.allow_route53](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+| Name                                                                                                                                                                     | Type        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| [aws_iam_policy.allow_route53](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)                                                   | resource    |
+| [aws_iam_role.allow_pathtolive_assume](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role)                                             | resource    |
+| [aws_iam_role_policy_attachment.allow_pathtolive_assume_route53](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource    |
+| [aws_route53_record.bichard7_dev_name_servers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                               | resource    |
+| [aws_route53_zone.bichard7_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone)                                     | resource    |
+| [aws_route53_zone.bichard7_dev_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone)                                 | resource    |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                            | data source |
+| [aws_caller_identity.sandbox_a](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                          | data source |
+| [aws_caller_identity.sandbox_b](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                          | data source |
+| [aws_caller_identity.sandbox_c](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                          | data source |
+| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                                       | data source |
+| [template_file.allow_route53](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file)                                                  | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_region"></a> [region](#input\_region) | The AWS region | `string` | `"eu-west-2"` | no |
-| <a name="input_sandbox_a_access_key"></a> [sandbox\_a\_access\_key](#input\_sandbox\_a\_access\_key) | the AWS\_ACCESS\_KEY\_ID for sandbox\_a | `string` | n/a | yes |
-| <a name="input_sandbox_a_secret_key"></a> [sandbox\_a\_secret\_key](#input\_sandbox\_a\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for sandbox\_a | `string` | n/a | yes |
-| <a name="input_sandbox_b_access_key"></a> [sandbox\_b\_access\_key](#input\_sandbox\_b\_access\_key) | the AWS\_ACCESS\_KEY\_ID for sandbox\_b | `string` | n/a | yes |
-| <a name="input_sandbox_b_secret_key"></a> [sandbox\_b\_secret\_key](#input\_sandbox\_b\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for sandbox\_b | `string` | n/a | yes |
-| <a name="input_sandbox_c_access_key"></a> [sandbox\_c\_access\_key](#input\_sandbox\_c\_access\_key) | the AWS\_ACCESS\_KEY\_ID for sandbox\_c | `string` | n/a | yes |
-| <a name="input_sandbox_c_secret_key"></a> [sandbox\_c\_secret\_key](#input\_sandbox\_c\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for sandbox\_c | `string` | n/a | yes |
+| Name                                                                                          | Description                             | Type     | Default       | Required |
+| --------------------------------------------------------------------------------------------- | --------------------------------------- | -------- | ------------- | :------: |
+| <a name="input_region"></a> [region](#input_region)                                           | The AWS region                          | `string` | `"eu-west-2"` |    no    |
+| <a name="input_sandbox_a_access_key"></a> [sandbox_a_access_key](#input_sandbox_a_access_key) | the AWS_ACCESS_KEY_ID for sandbox_a     | `string` | n/a           |   yes    |
+| <a name="input_sandbox_a_secret_key"></a> [sandbox_a_secret_key](#input_sandbox_a_secret_key) | the AWS_SECRET_ACCESS_KEY for sandbox_a | `string` | n/a           |   yes    |
+| <a name="input_sandbox_b_access_key"></a> [sandbox_b_access_key](#input_sandbox_b_access_key) | the AWS_ACCESS_KEY_ID for sandbox_b     | `string` | n/a           |   yes    |
+| <a name="input_sandbox_b_secret_key"></a> [sandbox_b_secret_key](#input_sandbox_b_secret_key) | the AWS_SECRET_ACCESS_KEY for sandbox_b | `string` | n/a           |   yes    |
+| <a name="input_sandbox_c_access_key"></a> [sandbox_c_access_key](#input_sandbox_c_access_key) | the AWS_ACCESS_KEY_ID for sandbox_c     | `string` | n/a           |   yes    |
+| <a name="input_sandbox_c_secret_key"></a> [sandbox_c_secret_key](#input_sandbox_c_secret_key) | the AWS_SECRET_ACCESS_KEY for sandbox_c | `string` | n/a           |   yes    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_admin_group_name"></a> [admin\_group\_name](#output\_admin\_group\_name) | The name of our admin group |
-| <a name="output_allow_route53_assume_arn"></a> [allow\_route53\_assume\_arn](#output\_allow\_route53\_assume\_arn) | The arn for the path to live assume role |
-| <a name="output_ci_group_name"></a> [ci\_group\_name](#output\_ci\_group\_name) | The name of our ci group |
-| <a name="output_ci_users"></a> [ci\_users](#output\_ci\_users) | A list of our CI users |
-| <a name="output_delegated_hosted_zone"></a> [delegated\_hosted\_zone](#output\_delegated\_hosted\_zone) | Our dev hosted zone |
-| <a name="output_mfa_group_name"></a> [mfa\_group\_name](#output\_mfa\_group\_name) | The name of our MFA group |
-| <a name="output_parent_delegated_hosted_zone"></a> [parent\_delegated\_hosted\_zone](#output\_parent\_delegated\_hosted\_zone) | Our delegated hosted zone |
-| <a name="output_readonly_group_name"></a> [readonly\_group\_name](#output\_readonly\_group\_name) | The name of our readonly group |
-| <a name="output_s3_logging_bucket_name"></a> [s3\_logging\_bucket\_name](#output\_s3\_logging\_bucket\_name) | The name of our shared logging bucket |
-| <a name="output_sandbox_a_admin_arn"></a> [sandbox\_a\_admin\_arn](#output\_sandbox\_a\_admin\_arn) | The sandbox\_a Admin Assume Role ARN |
-| <a name="output_sandbox_a_ci_arn"></a> [sandbox\_a\_ci\_arn](#output\_sandbox\_a\_ci\_arn) | The sandbox\_c CI Assume Role ARN |
-| <a name="output_sandbox_a_readonly_arn"></a> [sandbox\_a\_readonly\_arn](#output\_sandbox\_a\_readonly\_arn) | The sandbox\_a ReadOnly Assume Role ARN |
-| <a name="output_sandbox_b_admin_arn"></a> [sandbox\_b\_admin\_arn](#output\_sandbox\_b\_admin\_arn) | The sandbox\_b Admin Assume Role ARN |
-| <a name="output_sandbox_b_ci_arn"></a> [sandbox\_b\_ci\_arn](#output\_sandbox\_b\_ci\_arn) | The sandbox\_b CI Assume Role ARN |
-| <a name="output_sandbox_b_readonly_arn"></a> [sandbox\_b\_readonly\_arn](#output\_sandbox\_b\_readonly\_arn) | The sandbox\_b ReadOnly Assume Role ARN |
-| <a name="output_sandbox_c_admin_arn"></a> [sandbox\_c\_admin\_arn](#output\_sandbox\_c\_admin\_arn) | The sandbox\_c Admin Assume Role ARN |
-| <a name="output_sandbox_c_ci_arn"></a> [sandbox\_c\_ci\_arn](#output\_sandbox\_c\_ci\_arn) | The sandbox\_c CI Assume Role ARN |
-| <a name="output_sandbox_c_readonly_arn"></a> [sandbox\_c\_readonly\_arn](#output\_sandbox\_c\_readonly\_arn) | The sandbox\_c ReadOnly Assume Role ARN |
-| <a name="output_shared_ci_policy_arn"></a> [shared\_ci\_policy\_arn](#output\_shared\_ci\_policy\_arn) | The arn of our ci policy consumed by our codebuild jobs |
+| Name                                                                                                                    | Description                                             |
+| ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| <a name="output_admin_group_name"></a> [admin_group_name](#output_admin_group_name)                                     | The name of our admin group                             |
+| <a name="output_allow_route53_assume_arn"></a> [allow_route53_assume_arn](#output_allow_route53_assume_arn)             | The arn for the path to live assume role                |
+| <a name="output_ci_group_name"></a> [ci_group_name](#output_ci_group_name)                                              | The name of our ci group                                |
+| <a name="output_ci_users"></a> [ci_users](#output_ci_users)                                                             | A list of our CI users                                  |
+| <a name="output_delegated_hosted_zone"></a> [delegated_hosted_zone](#output_delegated_hosted_zone)                      | Our dev hosted zone                                     |
+| <a name="output_mfa_group_name"></a> [mfa_group_name](#output_mfa_group_name)                                           | The name of our MFA group                               |
+| <a name="output_parent_delegated_hosted_zone"></a> [parent_delegated_hosted_zone](#output_parent_delegated_hosted_zone) | Our delegated hosted zone                               |
+| <a name="output_readonly_group_name"></a> [readonly_group_name](#output_readonly_group_name)                            | The name of our readonly group                          |
+| <a name="output_s3_logging_bucket_name"></a> [s3_logging_bucket_name](#output_s3_logging_bucket_name)                   | The name of our shared logging bucket                   |
+| <a name="output_sandbox_a_admin_arn"></a> [sandbox_a_admin_arn](#output_sandbox_a_admin_arn)                            | The sandbox_a Admin Assume Role ARN                     |
+| <a name="output_sandbox_a_ci_arn"></a> [sandbox_a_ci_arn](#output_sandbox_a_ci_arn)                                     | The sandbox_c CI Assume Role ARN                        |
+| <a name="output_sandbox_a_readonly_arn"></a> [sandbox_a_readonly_arn](#output_sandbox_a_readonly_arn)                   | The sandbox_a ReadOnly Assume Role ARN                  |
+| <a name="output_sandbox_b_admin_arn"></a> [sandbox_b_admin_arn](#output_sandbox_b_admin_arn)                            | The sandbox_b Admin Assume Role ARN                     |
+| <a name="output_sandbox_b_ci_arn"></a> [sandbox_b_ci_arn](#output_sandbox_b_ci_arn)                                     | The sandbox_b CI Assume Role ARN                        |
+| <a name="output_sandbox_b_readonly_arn"></a> [sandbox_b_readonly_arn](#output_sandbox_b_readonly_arn)                   | The sandbox_b ReadOnly Assume Role ARN                  |
+| <a name="output_sandbox_c_admin_arn"></a> [sandbox_c_admin_arn](#output_sandbox_c_admin_arn)                            | The sandbox_c Admin Assume Role ARN                     |
+| <a name="output_sandbox_c_ci_arn"></a> [sandbox_c_ci_arn](#output_sandbox_c_ci_arn)                                     | The sandbox_c CI Assume Role ARN                        |
+| <a name="output_sandbox_c_readonly_arn"></a> [sandbox_c_readonly_arn](#output_sandbox_c_readonly_arn)                   | The sandbox_c ReadOnly Assume Role ARN                  |
+| <a name="output_shared_ci_policy_arn"></a> [shared_ci_policy_arn](#output_shared_ci_policy_arn)                         | The arn of our ci policy consumed by our codebuild jobs |
+
 <!-- END_TF_DOCS -->

--- a/terraform/shared_account_sandbox_infra/README.md
+++ b/terraform/shared_account_sandbox_infra/README.md
@@ -24,95 +24,93 @@ export TF_VAR_sandbox_c_secret_key=""
 ```
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version  |
-| ------------------------------------------------------------------------ | -------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
-| <a name="requirement_local"></a> [local](#requirement_local)             | ~> 2.0.0 |
-| <a name="requirement_null"></a> [null](#requirement_null)                | ~> 3.0.0 |
-| <a name="requirement_template"></a> [template](#requirement_template)    | ~> 2.2.0 |
-| <a name="requirement_tls"></a> [tls](#requirement_tls)                   | ~> 3.1.0 |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0.0 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | ~> 2.2.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.1.0 |
 
 ## Providers
 
-| Name                                                                                          | Version  |
-| --------------------------------------------------------------------------------------------- | -------- |
-| <a name="provider_aws"></a> [aws](#provider_aws)                                              | = 3.75.2 |
-| <a name="provider_aws.sandbox_a"></a> [aws.sandbox_a](#provider_aws.sandbox_a)                | = 3.75.2 |
-| <a name="provider_aws.sandbox_b"></a> [aws.sandbox_b](#provider_aws.sandbox_b)                | = 3.75.2 |
-| <a name="provider_aws.sandbox_c"></a> [aws.sandbox_c](#provider_aws.sandbox_c)                | = 3.75.2 |
-| <a name="provider_aws.sandbox_shared"></a> [aws.sandbox_shared](#provider_aws.sandbox_shared) | = 3.75.2 |
-| <a name="provider_template"></a> [template](#provider_template)                               | ~> 2.2.0 |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
+| <a name="provider_aws.sandbox_a"></a> [aws.sandbox\_a](#provider\_aws.sandbox\_a) | 3.75.2 |
+| <a name="provider_aws.sandbox_b"></a> [aws.sandbox\_b](#provider\_aws.sandbox\_b) | 3.75.2 |
+| <a name="provider_aws.sandbox_c"></a> [aws.sandbox\_c](#provider\_aws.sandbox\_c) | 3.75.2 |
+| <a name="provider_aws.sandbox_shared"></a> [aws.sandbox\_shared](#provider\_aws.sandbox\_shared) | 3.75.2 |
+| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
 
 ## Modules
 
-| Name                                                                                                                             | Source                                                                                                      | Version   |
-| -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | --------- |
-| <a name="module_aws_logs"></a> [aws_logs](#module_aws_logs)                                                                      | trussworks/logs/aws                                                                                         | ~> 10.3.0 |
-| <a name="module_label"></a> [label](#module_label)                                                                               | cloudposse/label/null                                                                                       | 0.24.1    |
-| <a name="module_sandbox_a_child_access"></a> [sandbox_a_child_access](#module_sandbox_a_child_access)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
-| <a name="module_sandbox_b_child_access"></a> [sandbox_b_child_access](#module_sandbox_b_child_access)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
-| <a name="module_sandbox_c_child_access"></a> [sandbox_c_child_access](#module_sandbox_c_child_access)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access  | n/a       |
-| <a name="module_shared_account_access_sandbox_a"></a> [shared_account_access_sandbox_a](#module_shared_account_access_sandbox_a) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
-| <a name="module_shared_account_access_sandbox_b"></a> [shared_account_access_sandbox_b](#module_shared_account_access_sandbox_b) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
-| <a name="module_shared_account_access_sandbox_c"></a> [shared_account_access_sandbox_c](#module_shared_account_access_sandbox_c) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a       |
-| <a name="module_shared_account_user_access"></a> [shared_account_user_access](#module_shared_account_user_access)                | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent        | n/a       |
-| <a name="module_tag_vars"></a> [tag_vars](#module_tag_vars)                                                                      | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars                     | n/a       |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aws_logs"></a> [aws\_logs](#module\_aws\_logs) | trussworks/logs/aws | ~> 10.3.0  |
+| <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_sandbox_a_child_access"></a> [sandbox\_a\_child\_access](#module\_sandbox\_a\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
+| <a name="module_sandbox_b_child_access"></a> [sandbox\_b\_child\_access](#module\_sandbox\_b\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
+| <a name="module_sandbox_c_child_access"></a> [sandbox\_c\_child\_access](#module\_sandbox\_c\_child\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_child_access | n/a |
+| <a name="module_shared_account_access_sandbox_a"></a> [shared\_account\_access\_sandbox\_a](#module\_shared\_account\_access\_sandbox\_a) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
+| <a name="module_shared_account_access_sandbox_b"></a> [shared\_account\_access\_sandbox\_b](#module\_shared\_account\_access\_sandbox\_b) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
+| <a name="module_shared_account_access_sandbox_c"></a> [shared\_account\_access\_sandbox\_c](#module\_shared\_account\_access\_sandbox\_c) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent_access | n/a |
+| <a name="module_shared_account_user_access"></a> [shared\_account\_user\_access](#module\_shared\_account\_user\_access) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/shared_account_parent | n/a |
+| <a name="module_tag_vars"></a> [tag\_vars](#module\_tag\_vars) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars | n/a |
 
 ## Resources
 
-| Name                                                                                                                                                                     | Type        |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
-| [aws_iam_policy.allow_route53](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)                                                   | resource    |
-| [aws_iam_role.allow_pathtolive_assume](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role)                                             | resource    |
-| [aws_iam_role_policy_attachment.allow_pathtolive_assume_route53](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource    |
-| [aws_route53_record.bichard7_dev_name_servers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                               | resource    |
-| [aws_route53_zone.bichard7_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone)                                     | resource    |
-| [aws_route53_zone.bichard7_dev_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone)                                 | resource    |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                            | data source |
-| [aws_caller_identity.sandbox_a](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                          | data source |
-| [aws_caller_identity.sandbox_b](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                          | data source |
-| [aws_caller_identity.sandbox_c](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                          | data source |
-| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                                       | data source |
-| [template_file.allow_route53](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file)                                                  | data source |
+| Name | Type |
+|------|------|
+| [aws_iam_policy.allow_route53](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
+| [aws_iam_role.allow_pathtolive_assume](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.allow_pathtolive_assume_route53](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_route53_record.bichard7_dev_name_servers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
+| [aws_route53_zone.bichard7_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone) | resource |
+| [aws_route53_zone.bichard7_dev_delegated_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_zone) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.sandbox_a](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.sandbox_b](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.sandbox_c](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
+| [template_file.allow_route53](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 
-| Name                                                                                          | Description                             | Type     | Default       | Required |
-| --------------------------------------------------------------------------------------------- | --------------------------------------- | -------- | ------------- | :------: |
-| <a name="input_region"></a> [region](#input_region)                                           | The AWS region                          | `string` | `"eu-west-2"` |    no    |
-| <a name="input_sandbox_a_access_key"></a> [sandbox_a_access_key](#input_sandbox_a_access_key) | the AWS_ACCESS_KEY_ID for sandbox_a     | `string` | n/a           |   yes    |
-| <a name="input_sandbox_a_secret_key"></a> [sandbox_a_secret_key](#input_sandbox_a_secret_key) | the AWS_SECRET_ACCESS_KEY for sandbox_a | `string` | n/a           |   yes    |
-| <a name="input_sandbox_b_access_key"></a> [sandbox_b_access_key](#input_sandbox_b_access_key) | the AWS_ACCESS_KEY_ID for sandbox_b     | `string` | n/a           |   yes    |
-| <a name="input_sandbox_b_secret_key"></a> [sandbox_b_secret_key](#input_sandbox_b_secret_key) | the AWS_SECRET_ACCESS_KEY for sandbox_b | `string` | n/a           |   yes    |
-| <a name="input_sandbox_c_access_key"></a> [sandbox_c_access_key](#input_sandbox_c_access_key) | the AWS_ACCESS_KEY_ID for sandbox_c     | `string` | n/a           |   yes    |
-| <a name="input_sandbox_c_secret_key"></a> [sandbox_c_secret_key](#input_sandbox_c_secret_key) | the AWS_SECRET_ACCESS_KEY for sandbox_c | `string` | n/a           |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_region"></a> [region](#input\_region) | The AWS region | `string` | `"eu-west-2"` | no |
+| <a name="input_sandbox_a_access_key"></a> [sandbox\_a\_access\_key](#input\_sandbox\_a\_access\_key) | the AWS\_ACCESS\_KEY\_ID for sandbox\_a | `string` | n/a | yes |
+| <a name="input_sandbox_a_secret_key"></a> [sandbox\_a\_secret\_key](#input\_sandbox\_a\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for sandbox\_a | `string` | n/a | yes |
+| <a name="input_sandbox_b_access_key"></a> [sandbox\_b\_access\_key](#input\_sandbox\_b\_access\_key) | the AWS\_ACCESS\_KEY\_ID for sandbox\_b | `string` | n/a | yes |
+| <a name="input_sandbox_b_secret_key"></a> [sandbox\_b\_secret\_key](#input\_sandbox\_b\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for sandbox\_b | `string` | n/a | yes |
+| <a name="input_sandbox_c_access_key"></a> [sandbox\_c\_access\_key](#input\_sandbox\_c\_access\_key) | the AWS\_ACCESS\_KEY\_ID for sandbox\_c | `string` | n/a | yes |
+| <a name="input_sandbox_c_secret_key"></a> [sandbox\_c\_secret\_key](#input\_sandbox\_c\_secret\_key) | the AWS\_SECRET\_ACCESS\_KEY for sandbox\_c | `string` | n/a | yes |
 
 ## Outputs
 
-| Name                                                                                                                    | Description                                             |
-| ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| <a name="output_admin_group_name"></a> [admin_group_name](#output_admin_group_name)                                     | The name of our admin group                             |
-| <a name="output_allow_route53_assume_arn"></a> [allow_route53_assume_arn](#output_allow_route53_assume_arn)             | The arn for the path to live assume role                |
-| <a name="output_ci_group_name"></a> [ci_group_name](#output_ci_group_name)                                              | The name of our ci group                                |
-| <a name="output_ci_users"></a> [ci_users](#output_ci_users)                                                             | A list of our CI users                                  |
-| <a name="output_delegated_hosted_zone"></a> [delegated_hosted_zone](#output_delegated_hosted_zone)                      | Our dev hosted zone                                     |
-| <a name="output_mfa_group_name"></a> [mfa_group_name](#output_mfa_group_name)                                           | The name of our MFA group                               |
-| <a name="output_parent_delegated_hosted_zone"></a> [parent_delegated_hosted_zone](#output_parent_delegated_hosted_zone) | Our delegated hosted zone                               |
-| <a name="output_readonly_group_name"></a> [readonly_group_name](#output_readonly_group_name)                            | The name of our readonly group                          |
-| <a name="output_s3_logging_bucket_name"></a> [s3_logging_bucket_name](#output_s3_logging_bucket_name)                   | The name of our shared logging bucket                   |
-| <a name="output_sandbox_a_admin_arn"></a> [sandbox_a_admin_arn](#output_sandbox_a_admin_arn)                            | The sandbox_a Admin Assume Role ARN                     |
-| <a name="output_sandbox_a_ci_arn"></a> [sandbox_a_ci_arn](#output_sandbox_a_ci_arn)                                     | The sandbox_c CI Assume Role ARN                        |
-| <a name="output_sandbox_a_readonly_arn"></a> [sandbox_a_readonly_arn](#output_sandbox_a_readonly_arn)                   | The sandbox_a ReadOnly Assume Role ARN                  |
-| <a name="output_sandbox_b_admin_arn"></a> [sandbox_b_admin_arn](#output_sandbox_b_admin_arn)                            | The sandbox_b Admin Assume Role ARN                     |
-| <a name="output_sandbox_b_ci_arn"></a> [sandbox_b_ci_arn](#output_sandbox_b_ci_arn)                                     | The sandbox_b CI Assume Role ARN                        |
-| <a name="output_sandbox_b_readonly_arn"></a> [sandbox_b_readonly_arn](#output_sandbox_b_readonly_arn)                   | The sandbox_b ReadOnly Assume Role ARN                  |
-| <a name="output_sandbox_c_admin_arn"></a> [sandbox_c_admin_arn](#output_sandbox_c_admin_arn)                            | The sandbox_c Admin Assume Role ARN                     |
-| <a name="output_sandbox_c_ci_arn"></a> [sandbox_c_ci_arn](#output_sandbox_c_ci_arn)                                     | The sandbox_c CI Assume Role ARN                        |
-| <a name="output_sandbox_c_readonly_arn"></a> [sandbox_c_readonly_arn](#output_sandbox_c_readonly_arn)                   | The sandbox_c ReadOnly Assume Role ARN                  |
-| <a name="output_shared_ci_policy_arn"></a> [shared_ci_policy_arn](#output_shared_ci_policy_arn)                         | The arn of our ci policy consumed by our codebuild jobs |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_admin_group_name"></a> [admin\_group\_name](#output\_admin\_group\_name) | The name of our admin group |
+| <a name="output_allow_route53_assume_arn"></a> [allow\_route53\_assume\_arn](#output\_allow\_route53\_assume\_arn) | The arn for the path to live assume role |
+| <a name="output_ci_group_name"></a> [ci\_group\_name](#output\_ci\_group\_name) | The name of our ci group |
+| <a name="output_ci_users"></a> [ci\_users](#output\_ci\_users) | A list of our CI users |
+| <a name="output_delegated_hosted_zone"></a> [delegated\_hosted\_zone](#output\_delegated\_hosted\_zone) | Our dev hosted zone |
+| <a name="output_mfa_group_name"></a> [mfa\_group\_name](#output\_mfa\_group\_name) | The name of our MFA group |
+| <a name="output_parent_delegated_hosted_zone"></a> [parent\_delegated\_hosted\_zone](#output\_parent\_delegated\_hosted\_zone) | Our delegated hosted zone |
+| <a name="output_readonly_group_name"></a> [readonly\_group\_name](#output\_readonly\_group\_name) | The name of our readonly group |
+| <a name="output_s3_logging_bucket_name"></a> [s3\_logging\_bucket\_name](#output\_s3\_logging\_bucket\_name) | The name of our shared logging bucket |
+| <a name="output_sandbox_a_admin_arn"></a> [sandbox\_a\_admin\_arn](#output\_sandbox\_a\_admin\_arn) | The sandbox\_a Admin Assume Role ARN |
+| <a name="output_sandbox_a_ci_arn"></a> [sandbox\_a\_ci\_arn](#output\_sandbox\_a\_ci\_arn) | The sandbox\_c CI Assume Role ARN |
+| <a name="output_sandbox_a_readonly_arn"></a> [sandbox\_a\_readonly\_arn](#output\_sandbox\_a\_readonly\_arn) | The sandbox\_a ReadOnly Assume Role ARN |
+| <a name="output_sandbox_b_admin_arn"></a> [sandbox\_b\_admin\_arn](#output\_sandbox\_b\_admin\_arn) | The sandbox\_b Admin Assume Role ARN |
+| <a name="output_sandbox_b_ci_arn"></a> [sandbox\_b\_ci\_arn](#output\_sandbox\_b\_ci\_arn) | The sandbox\_b CI Assume Role ARN |
+| <a name="output_sandbox_b_readonly_arn"></a> [sandbox\_b\_readonly\_arn](#output\_sandbox\_b\_readonly\_arn) | The sandbox\_b ReadOnly Assume Role ARN |
+| <a name="output_sandbox_c_admin_arn"></a> [sandbox\_c\_admin\_arn](#output\_sandbox\_c\_admin\_arn) | The sandbox\_c Admin Assume Role ARN |
+| <a name="output_sandbox_c_ci_arn"></a> [sandbox\_c\_ci\_arn](#output\_sandbox\_c\_ci\_arn) | The sandbox\_c CI Assume Role ARN |
+| <a name="output_sandbox_c_readonly_arn"></a> [sandbox\_c\_readonly\_arn](#output\_sandbox\_c\_readonly\_arn) | The sandbox\_c ReadOnly Assume Role ARN |
+| <a name="output_shared_ci_policy_arn"></a> [shared\_ci\_policy\_arn](#output\_shared\_ci\_policy\_arn) | The arn of our ci policy consumed by our codebuild jobs |
 <!-- END_TF_DOCS -->

--- a/terraform/shared_account_sandbox_infra_ci/README.md
+++ b/terraform/shared_account_sandbox_infra_ci/README.md
@@ -3,85 +3,87 @@
 Creates various codebuild/codepipeline jobs and a codebuild vpc for our path to live account
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0.0 |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
+| <a name="requirement_local"></a> [local](#requirement_local)             | ~> 2.0.0 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_aws.sandbox_a"></a> [aws.sandbox\_a](#provider\_aws.sandbox\_a) | 3.75.2 |
-| <a name="provider_aws.sandbox_b"></a> [aws.sandbox\_b](#provider\_aws.sandbox\_b) | 3.75.2 |
-| <a name="provider_aws.sandbox_c"></a> [aws.sandbox\_c](#provider\_aws.sandbox\_c) | 3.75.2 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.1.0 |
-| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+| Name                                                                           | Version |
+| ------------------------------------------------------------------------------ | ------- |
+| <a name="provider_aws"></a> [aws](#provider_aws)                               | 3.75.2  |
+| <a name="provider_aws.sandbox_a"></a> [aws.sandbox_a](#provider_aws.sandbox_a) | 3.75.2  |
+| <a name="provider_aws.sandbox_b"></a> [aws.sandbox_b](#provider_aws.sandbox_b) | 3.75.2  |
+| <a name="provider_aws.sandbox_c"></a> [aws.sandbox_c](#provider_aws.sandbox_c) | 3.75.2  |
+| <a name="provider_external"></a> [external](#provider_external)                | 2.1.0   |
+| <a name="provider_terraform"></a> [terraform](#provider_terraform)             | n/a     |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_apply_nuke_sandbox_schedule"></a> [apply\_nuke\_sandbox\_schedule](#module\_apply\_nuke\_sandbox\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_codebuild_base_resources"></a> [codebuild\_base\_resources](#module\_codebuild\_base\_resources) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_base_resources | n/a |
-| <a name="module_codebuild_docker_resources"></a> [codebuild\_docker\_resources](#module\_codebuild\_docker\_resources) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/aws_ecr_repositories | n/a |
-| <a name="module_common_build_jobs"></a> [common\_build\_jobs](#module\_common\_build\_jobs) | ../modules/shared_cd_common_jobs | n/a |
-| <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
-| <a name="module_nuke_sandbox"></a> [nuke\_sandbox](#module\_nuke\_sandbox) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_scoutsuite_scan_sandbox_a"></a> [scoutsuite\_scan\_sandbox\_a](#module\_scoutsuite\_scan\_sandbox\_a) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_scoutsuite_scan_sandbox_a_schedule"></a> [scoutsuite\_scan\_sandbox\_a\_schedule](#module\_scoutsuite\_scan\_sandbox\_a\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_scoutsuite_scan_sandbox_b"></a> [scoutsuite\_scan\_sandbox\_b](#module\_scoutsuite\_scan\_sandbox\_b) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_scoutsuite_scan_sandbox_b_schedule"></a> [scoutsuite\_scan\_sandbox\_b\_schedule](#module\_scoutsuite\_scan\_sandbox\_b\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_scoutsuite_scan_sandbox_c"></a> [scoutsuite\_scan\_sandbox\_c](#module\_scoutsuite\_scan\_sandbox\_c) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_scoutsuite_scan_sandbox_c_schedule"></a> [scoutsuite\_scan\_sandbox\_c\_schedule](#module\_scoutsuite\_scan\_sandbox\_c\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_scoutsuite_scan_shared"></a> [scoutsuite\_scan\_shared](#module\_scoutsuite\_scan\_shared) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
-| <a name="module_scoutsuite_scan_shared_schedule"></a> [scoutsuite\_scan\_shared\_schedule](#module\_scoutsuite\_scan\_shared\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
-| <a name="module_tag_vars"></a> [tag\_vars](#module\_tag\_vars) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars | n/a |
+| Name                                                                                                                                      | Source                                                                                                  | Version |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------- |
+| <a name="module_apply_nuke_sandbox_schedule"></a> [apply_nuke_sandbox_schedule](#module_apply_nuke_sandbox_schedule)                      | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_codebuild_base_resources"></a> [codebuild_base_resources](#module_codebuild_base_resources)                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_base_resources | n/a     |
+| <a name="module_codebuild_docker_resources"></a> [codebuild_docker_resources](#module_codebuild_docker_resources)                         | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/aws_ecr_repositories     | n/a     |
+| <a name="module_common_build_jobs"></a> [common_build_jobs](#module_common_build_jobs)                                                    | ../modules/shared_cd_common_jobs                                                                        | n/a     |
+| <a name="module_label"></a> [label](#module_label)                                                                                        | cloudposse/label/null                                                                                   | 0.24.1  |
+| <a name="module_nuke_sandbox"></a> [nuke_sandbox](#module_nuke_sandbox)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_scoutsuite_scan_sandbox_a"></a> [scoutsuite_scan_sandbox_a](#module_scoutsuite_scan_sandbox_a)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_scoutsuite_scan_sandbox_a_schedule"></a> [scoutsuite_scan_sandbox_a_schedule](#module_scoutsuite_scan_sandbox_a_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_scoutsuite_scan_sandbox_b"></a> [scoutsuite_scan_sandbox_b](#module_scoutsuite_scan_sandbox_b)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_scoutsuite_scan_sandbox_b_schedule"></a> [scoutsuite_scan_sandbox_b_schedule](#module_scoutsuite_scan_sandbox_b_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_scoutsuite_scan_sandbox_c"></a> [scoutsuite_scan_sandbox_c](#module_scoutsuite_scan_sandbox_c)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_scoutsuite_scan_sandbox_c_schedule"></a> [scoutsuite_scan_sandbox_c_schedule](#module_scoutsuite_scan_sandbox_c_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_scoutsuite_scan_shared"></a> [scoutsuite_scan_shared](#module_scoutsuite_scan_shared)                                     | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
+| <a name="module_scoutsuite_scan_shared_schedule"></a> [scoutsuite_scan_shared_schedule](#module_scoutsuite_scan_shared_schedule)          | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
+| <a name="module_tag_vars"></a> [tag_vars](#module_tag_vars)                                                                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars                 | n/a     |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_iam_role_policy.allow_sandbox_a_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.allow_sandbox_b_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.allow_sandbox_c_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_user_policy.allow_ci_cloudfront](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy) | resource |
-| [aws_iam_user_policy.allow_ci_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.sandbox_a](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.sandbox_b](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_caller_identity.sandbox_c](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_ecr_repository.codebuild_base](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository) | data source |
-| [aws_ecr_repository.was](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository) | data source |
-| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
-| [external_external.latest_codebuild_base](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
-| [external_external.latest_was_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
-| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| Name                                                                                                                                                | Type        |
+| --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_iam_role_policy.allow_sandbox_a_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource    |
+| [aws_iam_role_policy.allow_sandbox_b_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource    |
+| [aws_iam_role_policy.allow_sandbox_c_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource    |
+| [aws_iam_user_policy.allow_ci_cloudfront](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy)              | resource    |
+| [aws_iam_user_policy.allow_ci_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy)        | resource    |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                       | data source |
+| [aws_caller_identity.sandbox_a](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                     | data source |
+| [aws_caller_identity.sandbox_b](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                     | data source |
+| [aws_caller_identity.sandbox_c](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                     | data source |
+| [aws_ecr_repository.codebuild_base](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository)                  | data source |
+| [aws_ecr_repository.was](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository)                             | data source |
+| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                  | data source |
+| [external_external.latest_codebuild_base](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external)             | data source |
+| [external_external.latest_was_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external)                  | data source |
+| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state)            | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_is_cd"></a> [is\_cd](#input\_is\_cd) | Is this being run by CD | `bool` | `false` | no |
-| <a name="input_slack_webhook"></a> [slack\_webhook](#input\_slack\_webhook) | Our webhook for sending messages to slack | `string` | `""` | no |
+| Name                                                                     | Description                               | Type     | Default | Required |
+| ------------------------------------------------------------------------ | ----------------------------------------- | -------- | ------- | :------: |
+| <a name="input_is_cd"></a> [is_cd](#input_is_cd)                         | Is this being run by CD                   | `bool`   | `false` |    no    |
+| <a name="input_slack_webhook"></a> [slack_webhook](#input_slack_webhook) | Our webhook for sending messages to slack | `string` | `""`    |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_base_resources"></a> [base\_resources](#output\_base\_resources) | The outputs for our base resources |
-| <a name="output_bichard_liberty_ecr"></a> [bichard\_liberty\_ecr](#output\_bichard\_liberty\_ecr) | The Bichard Liberty ecr repository details |
-| <a name="output_codebuild_cidr_block"></a> [codebuild\_cidr\_block](#output\_codebuild\_cidr\_block) | The cidr block for our codebuild vpc |
-| <a name="output_codebuild_private_cidr_blocks"></a> [codebuild\_private\_cidr\_blocks](#output\_codebuild\_private\_cidr\_blocks) | A list of private cidr blocks |
-| <a name="output_codebuild_subnet_ids"></a> [codebuild\_subnet\_ids](#output\_codebuild\_subnet\_ids) | A list of private subnet ids |
-| <a name="output_codebuild_vpc_id"></a> [codebuild\_vpc\_id](#output\_codebuild\_vpc\_id) | The vpc ID for our codebuild vpc |
-| <a name="output_prometheus_cloudwatch_exporter_repository_arn"></a> [prometheus\_cloudwatch\_exporter\_repository\_arn](#output\_prometheus\_cloudwatch\_exporter\_repository\_arn) | The repository arn for our prometheus cloudwatch exporter image |
-| <a name="output_prometheus_cloudwatch_exporter_repository_url"></a> [prometheus\_cloudwatch\_exporter\_repository\_url](#output\_prometheus\_cloudwatch\_exporter\_repository\_url) | The repository url for our prometheus cloudwatch exporter image |
-| <a name="output_prometheus_repository_arn"></a> [prometheus\_repository\_arn](#output\_prometheus\_repository\_arn) | The repository arn for our prometheus image |
-| <a name="output_prometheus_repository_url"></a> [prometheus\_repository\_url](#output\_prometheus\_repository\_url) | The repository url for our prometheus image |
-| <a name="output_staged_docker_resources"></a> [staged\_docker\_resources](#output\_staged\_docker\_resources) | The outputs from our staged docker images module |
+| Name                                                                                                                                                                       | Description                                                     |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| <a name="output_base_resources"></a> [base_resources](#output_base_resources)                                                                                              | The outputs for our base resources                              |
+| <a name="output_bichard_liberty_ecr"></a> [bichard_liberty_ecr](#output_bichard_liberty_ecr)                                                                               | The Bichard Liberty ecr repository details                      |
+| <a name="output_codebuild_cidr_block"></a> [codebuild_cidr_block](#output_codebuild_cidr_block)                                                                            | The cidr block for our codebuild vpc                            |
+| <a name="output_codebuild_private_cidr_blocks"></a> [codebuild_private_cidr_blocks](#output_codebuild_private_cidr_blocks)                                                 | A list of private cidr blocks                                   |
+| <a name="output_codebuild_subnet_ids"></a> [codebuild_subnet_ids](#output_codebuild_subnet_ids)                                                                            | A list of private subnet ids                                    |
+| <a name="output_codebuild_vpc_id"></a> [codebuild_vpc_id](#output_codebuild_vpc_id)                                                                                        | The vpc ID for our codebuild vpc                                |
+| <a name="output_prometheus_cloudwatch_exporter_repository_arn"></a> [prometheus_cloudwatch_exporter_repository_arn](#output_prometheus_cloudwatch_exporter_repository_arn) | The repository arn for our prometheus cloudwatch exporter image |
+| <a name="output_prometheus_cloudwatch_exporter_repository_url"></a> [prometheus_cloudwatch_exporter_repository_url](#output_prometheus_cloudwatch_exporter_repository_url) | The repository url for our prometheus cloudwatch exporter image |
+| <a name="output_prometheus_repository_arn"></a> [prometheus_repository_arn](#output_prometheus_repository_arn)                                                             | The repository arn for our prometheus image                     |
+| <a name="output_prometheus_repository_url"></a> [prometheus_repository_url](#output_prometheus_repository_url)                                                             | The repository url for our prometheus image                     |
+| <a name="output_staged_docker_resources"></a> [staged_docker_resources](#output_staged_docker_resources)                                                                   | The outputs from our staged docker images module                |
+
 <!-- END_TF_DOCS -->

--- a/terraform/shared_account_sandbox_infra_ci/README.md
+++ b/terraform/shared_account_sandbox_infra_ci/README.md
@@ -3,87 +3,85 @@
 Creates various codebuild/codepipeline jobs and a codebuild vpc for our path to live account
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version  |
-| ------------------------------------------------------------------------ | -------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
-| <a name="requirement_local"></a> [local](#requirement_local)             | ~> 2.0.0 |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0.0 |
 
 ## Providers
 
-| Name                                                                           | Version  |
-| ------------------------------------------------------------------------------ | -------- |
-| <a name="provider_aws"></a> [aws](#provider_aws)                               | = 3.75.2 |
-| <a name="provider_aws.sandbox_a"></a> [aws.sandbox_a](#provider_aws.sandbox_a) | = 3.75.2 |
-| <a name="provider_aws.sandbox_b"></a> [aws.sandbox_b](#provider_aws.sandbox_b) | = 3.75.2 |
-| <a name="provider_aws.sandbox_c"></a> [aws.sandbox_c](#provider_aws.sandbox_c) | = 3.75.2 |
-| <a name="provider_external"></a> [external](#provider_external)                | n/a      |
-| <a name="provider_terraform"></a> [terraform](#provider_terraform)             | n/a      |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
+| <a name="provider_aws.sandbox_a"></a> [aws.sandbox\_a](#provider\_aws.sandbox\_a) | 3.75.2 |
+| <a name="provider_aws.sandbox_b"></a> [aws.sandbox\_b](#provider\_aws.sandbox\_b) | 3.75.2 |
+| <a name="provider_aws.sandbox_c"></a> [aws.sandbox\_c](#provider\_aws.sandbox\_c) | 3.75.2 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.1.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
-| Name                                                                                                                                      | Source                                                                                                  | Version |
-| ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------- |
-| <a name="module_apply_nuke_sandbox_schedule"></a> [apply_nuke_sandbox_schedule](#module_apply_nuke_sandbox_schedule)                      | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_codebuild_base_resources"></a> [codebuild_base_resources](#module_codebuild_base_resources)                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_base_resources | n/a     |
-| <a name="module_codebuild_docker_resources"></a> [codebuild_docker_resources](#module_codebuild_docker_resources)                         | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/aws_ecr_repositories     | n/a     |
-| <a name="module_common_build_jobs"></a> [common_build_jobs](#module_common_build_jobs)                                                    | ../modules/shared_cd_common_jobs                                                                        | n/a     |
-| <a name="module_label"></a> [label](#module_label)                                                                                        | cloudposse/label/null                                                                                   | 0.24.1  |
-| <a name="module_nuke_sandbox"></a> [nuke_sandbox](#module_nuke_sandbox)                                                                   | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_scoutsuite_scan_sandbox_a"></a> [scoutsuite_scan_sandbox_a](#module_scoutsuite_scan_sandbox_a)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_scoutsuite_scan_sandbox_a_schedule"></a> [scoutsuite_scan_sandbox_a_schedule](#module_scoutsuite_scan_sandbox_a_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_scoutsuite_scan_sandbox_b"></a> [scoutsuite_scan_sandbox_b](#module_scoutsuite_scan_sandbox_b)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_scoutsuite_scan_sandbox_b_schedule"></a> [scoutsuite_scan_sandbox_b_schedule](#module_scoutsuite_scan_sandbox_b_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_scoutsuite_scan_sandbox_c"></a> [scoutsuite_scan_sandbox_c](#module_scoutsuite_scan_sandbox_c)                            | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_scoutsuite_scan_sandbox_c_schedule"></a> [scoutsuite_scan_sandbox_c_schedule](#module_scoutsuite_scan_sandbox_c_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_scoutsuite_scan_shared"></a> [scoutsuite_scan_shared](#module_scoutsuite_scan_shared)                                     | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job            | n/a     |
-| <a name="module_scoutsuite_scan_shared_schedule"></a> [scoutsuite_scan_shared_schedule](#module_scoutsuite_scan_shared_schedule)          | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule       | n/a     |
-| <a name="module_tag_vars"></a> [tag_vars](#module_tag_vars)                                                                               | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars                 | n/a     |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_apply_nuke_sandbox_schedule"></a> [apply\_nuke\_sandbox\_schedule](#module\_apply\_nuke\_sandbox\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_codebuild_base_resources"></a> [codebuild\_base\_resources](#module\_codebuild\_base\_resources) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_base_resources | n/a |
+| <a name="module_codebuild_docker_resources"></a> [codebuild\_docker\_resources](#module\_codebuild\_docker\_resources) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/aws_ecr_repositories | n/a |
+| <a name="module_common_build_jobs"></a> [common\_build\_jobs](#module\_common\_build\_jobs) | ../modules/shared_cd_common_jobs | n/a |
+| <a name="module_label"></a> [label](#module\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_nuke_sandbox"></a> [nuke\_sandbox](#module\_nuke\_sandbox) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_scoutsuite_scan_sandbox_a"></a> [scoutsuite\_scan\_sandbox\_a](#module\_scoutsuite\_scan\_sandbox\_a) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_scoutsuite_scan_sandbox_a_schedule"></a> [scoutsuite\_scan\_sandbox\_a\_schedule](#module\_scoutsuite\_scan\_sandbox\_a\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_scoutsuite_scan_sandbox_b"></a> [scoutsuite\_scan\_sandbox\_b](#module\_scoutsuite\_scan\_sandbox\_b) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_scoutsuite_scan_sandbox_b_schedule"></a> [scoutsuite\_scan\_sandbox\_b\_schedule](#module\_scoutsuite\_scan\_sandbox\_b\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_scoutsuite_scan_sandbox_c"></a> [scoutsuite\_scan\_sandbox\_c](#module\_scoutsuite\_scan\_sandbox\_c) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_scoutsuite_scan_sandbox_c_schedule"></a> [scoutsuite\_scan\_sandbox\_c\_schedule](#module\_scoutsuite\_scan\_sandbox\_c\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_scoutsuite_scan_shared"></a> [scoutsuite\_scan\_shared](#module\_scoutsuite\_scan\_shared) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_job | n/a |
+| <a name="module_scoutsuite_scan_shared_schedule"></a> [scoutsuite\_scan\_shared\_schedule](#module\_scoutsuite\_scan\_shared\_schedule) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/codebuild_schedule | n/a |
+| <a name="module_tag_vars"></a> [tag\_vars](#module\_tag\_vars) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/tag_vars | n/a |
 
 ## Resources
 
-| Name                                                                                                                                                | Type        |
-| --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [aws_iam_role_policy.allow_sandbox_a_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource    |
-| [aws_iam_role_policy.allow_sandbox_b_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource    |
-| [aws_iam_role_policy.allow_sandbox_c_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource    |
-| [aws_iam_user_policy.allow_ci_cloudfront](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy)              | resource    |
-| [aws_iam_user_policy.allow_ci_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy)        | resource    |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                       | data source |
-| [aws_caller_identity.sandbox_a](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                     | data source |
-| [aws_caller_identity.sandbox_b](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                     | data source |
-| [aws_caller_identity.sandbox_c](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                     | data source |
-| [aws_ecr_repository.codebuild_base](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository)                  | data source |
-| [aws_ecr_repository.was](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository)                             | data source |
-| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                  | data source |
-| [external_external.latest_codebuild_base](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external)             | data source |
-| [external_external.latest_was_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external)                  | data source |
-| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state)            | data source |
+| Name | Type |
+|------|------|
+| [aws_iam_role_policy.allow_sandbox_a_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.allow_sandbox_b_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.allow_sandbox_c_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
+| [aws_iam_user_policy.allow_ci_cloudfront](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy) | resource |
+| [aws_iam_user_policy.allow_ci_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.sandbox_a](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.sandbox_b](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_caller_identity.sandbox_c](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
+| [aws_ecr_repository.codebuild_base](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository) | data source |
+| [aws_ecr_repository.was](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ecr_repository) | data source |
+| [aws_region.current_region](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
+| [external_external.latest_codebuild_base](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
+| [external_external.latest_was_image](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
+| [terraform_remote_state.shared_infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs
 
-| Name                                                                     | Description                               | Type     | Default | Required |
-| ------------------------------------------------------------------------ | ----------------------------------------- | -------- | ------- | :------: |
-| <a name="input_is_cd"></a> [is_cd](#input_is_cd)                         | Is this being run by CD                   | `bool`   | `false` |    no    |
-| <a name="input_slack_webhook"></a> [slack_webhook](#input_slack_webhook) | Our webhook for sending messages to slack | `string` | `""`    |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_is_cd"></a> [is\_cd](#input\_is\_cd) | Is this being run by CD | `bool` | `false` | no |
+| <a name="input_slack_webhook"></a> [slack\_webhook](#input\_slack\_webhook) | Our webhook for sending messages to slack | `string` | `""` | no |
 
 ## Outputs
 
-| Name                                                                                                                                                                       | Description                                                     |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| <a name="output_base_resources"></a> [base_resources](#output_base_resources)                                                                                              | The outputs for our base resources                              |
-| <a name="output_bichard_liberty_ecr"></a> [bichard_liberty_ecr](#output_bichard_liberty_ecr)                                                                               | The Bichard Liberty ecr repository details                      |
-| <a name="output_codebuild_cidr_block"></a> [codebuild_cidr_block](#output_codebuild_cidr_block)                                                                            | The cidr block for our codebuild vpc                            |
-| <a name="output_codebuild_private_cidr_blocks"></a> [codebuild_private_cidr_blocks](#output_codebuild_private_cidr_blocks)                                                 | A list of private cidr blocks                                   |
-| <a name="output_codebuild_subnet_ids"></a> [codebuild_subnet_ids](#output_codebuild_subnet_ids)                                                                            | A list of private subnet ids                                    |
-| <a name="output_codebuild_vpc_id"></a> [codebuild_vpc_id](#output_codebuild_vpc_id)                                                                                        | The vpc ID for our codebuild vpc                                |
-| <a name="output_prometheus_cloudwatch_exporter_repository_arn"></a> [prometheus_cloudwatch_exporter_repository_arn](#output_prometheus_cloudwatch_exporter_repository_arn) | The repository arn for our prometheus cloudwatch exporter image |
-| <a name="output_prometheus_cloudwatch_exporter_repository_url"></a> [prometheus_cloudwatch_exporter_repository_url](#output_prometheus_cloudwatch_exporter_repository_url) | The repository url for our prometheus cloudwatch exporter image |
-| <a name="output_prometheus_repository_arn"></a> [prometheus_repository_arn](#output_prometheus_repository_arn)                                                             | The repository arn for our prometheus image                     |
-| <a name="output_prometheus_repository_url"></a> [prometheus_repository_url](#output_prometheus_repository_url)                                                             | The repository url for our prometheus image                     |
-| <a name="output_staged_docker_resources"></a> [staged_docker_resources](#output_staged_docker_resources)                                                                   | The outputs from our staged docker images module                |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_base_resources"></a> [base\_resources](#output\_base\_resources) | The outputs for our base resources |
+| <a name="output_bichard_liberty_ecr"></a> [bichard\_liberty\_ecr](#output\_bichard\_liberty\_ecr) | The Bichard Liberty ecr repository details |
+| <a name="output_codebuild_cidr_block"></a> [codebuild\_cidr\_block](#output\_codebuild\_cidr\_block) | The cidr block for our codebuild vpc |
+| <a name="output_codebuild_private_cidr_blocks"></a> [codebuild\_private\_cidr\_blocks](#output\_codebuild\_private\_cidr\_blocks) | A list of private cidr blocks |
+| <a name="output_codebuild_subnet_ids"></a> [codebuild\_subnet\_ids](#output\_codebuild\_subnet\_ids) | A list of private subnet ids |
+| <a name="output_codebuild_vpc_id"></a> [codebuild\_vpc\_id](#output\_codebuild\_vpc\_id) | The vpc ID for our codebuild vpc |
+| <a name="output_prometheus_cloudwatch_exporter_repository_arn"></a> [prometheus\_cloudwatch\_exporter\_repository\_arn](#output\_prometheus\_cloudwatch\_exporter\_repository\_arn) | The repository arn for our prometheus cloudwatch exporter image |
+| <a name="output_prometheus_cloudwatch_exporter_repository_url"></a> [prometheus\_cloudwatch\_exporter\_repository\_url](#output\_prometheus\_cloudwatch\_exporter\_repository\_url) | The repository url for our prometheus cloudwatch exporter image |
+| <a name="output_prometheus_repository_arn"></a> [prometheus\_repository\_arn](#output\_prometheus\_repository\_arn) | The repository arn for our prometheus image |
+| <a name="output_prometheus_repository_url"></a> [prometheus\_repository\_url](#output\_prometheus\_repository\_url) | The repository url for our prometheus image |
+| <a name="output_staged_docker_resources"></a> [staged\_docker\_resources](#output\_staged\_docker\_resources) | The outputs from our staged docker images module |
 <!-- END_TF_DOCS -->


### PR DESCRIPTION
* import the `INFRA_MODULES_COMMIT_HASH` to e2e, preprod and production

The same commit hash is passed to each stage because it is exported into the "HASHES" namespace (see below pr)

This var is exported in this [PR](https://github.com/ministryofjustice/bichard7-next-infrastructure/pull/964)