### PR TITLE
Update Bichard7-CI-Access role to tag and untag MWAA environment

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/iam.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/iam.tf
@@ -82,6 +82,12 @@ resource "aws_iam_role_policy" "allow_integration_next_codebuild_bucket" {
           "${module.codebuild_base_resources.codepipeline_bucket_arn}",
           "${module.codebuild_base_resources.codepipeline_bucket_arn}/*"
         ]
+      },
+      {
+        "Sid": "TagUntagAirflow",
+        "Effect": "Allow",
+        "Action": ["airflow:TagResource", "airflow:UntagResource"],
+        "Resource": ["arn:aws:airflow:*:*:environment/*"]
       }
     ]
   }
@@ -119,6 +125,12 @@ resource "aws_iam_role_policy" "allow_integration_baseline_codebuild_bucket" {
           "${module.codebuild_base_resources.codepipeline_bucket_arn}",
           "${module.codebuild_base_resources.codepipeline_bucket_arn}/*"
         ]
+      },
+      {
+        "Sid": "TagUntagAirflow",
+        "Effect": "Allow",
+        "Action": ["airflow:TagResource", "airflow:UntagResource"],
+        "Resource": ["arn:aws:airflow:*:*:environment/*"]
       }
     ]
   }
@@ -156,6 +168,12 @@ resource "aws_iam_role_policy" "allow_qsolution_codebuild_bucket" {
           "${module.codebuild_base_resources.codepipeline_bucket_arn}",
           "${module.codebuild_base_resources.codepipeline_bucket_arn}/*"
         ]
+      },
+      {
+        "Sid": "TagUntagAirflow",
+        "Effect": "Allow",
+        "Action": ["airflow:TagResource", "airflow:UntagResource"],
+        "Resource": ["arn:aws:airflow:*:*:environment/*"]
       }
     ]
   }
@@ -197,6 +215,12 @@ resource "aws_iam_role_policy" "allow_production_codebuild_bucket" {
           "${module.codebuild_base_resources.codepipeline_bucket_arn}",
           "${module.codebuild_base_resources.codepipeline_bucket_arn}/*"
         ]
+      },
+      {
+        "Sid": "TagUntagAirflow",
+        "Effect": "Allow",
+        "Action": ["airflow:TagResource", "airflow:UntagResource"],
+        "Resource": ["arn:aws:airflow:*:*:environment/*"]
       }
     ]
   }


### PR DESCRIPTION
This PR updates `Bichard7-CI-Access` role to allow the CI user to tag and untag the MWAA environment