### PR TITLE
Bump container size for core build

### DIFF
--- a/terraform/modules/shared_cd_common_jobs/build_core.tf
+++ b/terraform/modules/shared_cd_common_jobs/build_core.tf
@@ -12,7 +12,7 @@ module "build_core" {
 
   build_environments = [
     {
-      compute_type    = "BUILD_GENERAL1_MEDIUM"
+      compute_type    = "BUILD_GENERAL1_LARGE"
       image           = "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
       type            = "LINUX_CONTAINER"
       privileged_mode = true


### PR DESCRIPTION
This has been failing because it's been running out of memory, but succeeds with the increased container size