### PR TITLE
Seed the e2e environment with generated data

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
@@ -132,12 +132,26 @@ module "seed_e2e_data" {
   source = "../modules/codebuild_job"
   name = "seed-e2e-data"
   build_description = "Seed the database with generated case data"
-  report_build_status = true
 
   repository_name = "bichard7-next-ui"
   buildspec_file = "seed-data-buildspec.yml"
 
-  environment_variables = local.bichard_cd_vars
+  environment_variables = concat(
+    [
+      {
+        name = "WORKSPACE"
+        value = "e2e-test"
+      }
+    ],
+    local.bichard_cd_vars, )
+
+  allowed_resource_arns = [
+    data.aws_ecr_repository.codebuild_base.arn
+  ]
+
+  codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
+  sns_notification_arn   = module.codebuild_base_resources.notifications_arn
+  sns_kms_key_arn        = module.codebuild_base_resources.notifications_kms_key_arn
 
   tags = module.label.tags
 }

--- a/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
@@ -127,3 +127,17 @@ module "run_e2e_tests_restart_pnc_container" {
 
   tags = module.label.tags
 }
+
+module "seed_e2e_data" {
+  source = "../modules/codebuild_job"
+  name = "seed-e2e-data"
+  build_description = "Seed the database with generated case data"
+  report_build_status = true
+
+  repository_name = "bichard7-next-ui"
+  buildspec_file = "seed-data-buildspec.yml"
+
+  environment_variables = local.bichard_cd_vars
+
+  tags = module.label.tags
+}

--- a/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
@@ -129,21 +129,21 @@ module "run_e2e_tests_restart_pnc_container" {
 }
 
 module "seed_e2e_data" {
-  source = "../modules/codebuild_job"
-  name = "seed-e2e-data"
+  source            = "../modules/codebuild_job"
+  name              = "seed-e2e-data"
   build_description = "Seed the database with generated case data"
 
   repository_name = "bichard7-next-ui"
-  buildspec_file = "seed-data-buildspec.yml"
+  buildspec_file  = "seed-data-buildspec.yml"
 
   environment_variables = concat(
     [
       {
-        name = "WORKSPACE"
+        name  = "WORKSPACE"
         value = "e2e-test"
       }
     ],
-    local.bichard_cd_vars, )
+  local.bichard_cd_vars)
 
   allowed_resource_arns = [
     data.aws_ecr_repository.codebuild_base.arn

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -330,11 +330,11 @@ resource "aws_codepipeline" "path_to_live" {
     }
 
     action {
-      category = "Build"
-      name = "seed-e2e-data"
-      owner = "AWS"
-      provider = "CodeBuild"
-      version = "1"
+      category  = "Build"
+      name      = "seed-e2e-data"
+      owner     = "AWS"
+      provider  = "CodeBuild"
+      version   = "1"
       run_order = 3
       configuration = {
         ProjectName = module.seed_e2e_data.pipeline_name

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -330,12 +330,30 @@ resource "aws_codepipeline" "path_to_live" {
     }
 
     action {
+      category = "Build"
+      name = "seed-e2e-data"
+      owner = "AWS"
+      provider = "CodeBuild"
+      version = "1"
+      run_order = 3
+      configuration = {
+        ProjectName = module.seed_e2e_data.pipeline_name
+      }
+
+      input_artifacts = [
+        "infrastructure",
+        "application",
+        "ui-semaphore"
+      ]
+    }
+
+    action {
       category  = "Build"
       name      = "remove-dev-sgs-from-e2e-test"
       owner     = "AWS"
       provider  = "CodeBuild"
       version   = "1"
-      run_order = 3
+      run_order = 4
       configuration = {
         ProjectName = module.remove_dev_sg_from_e2e_test.pipeline_name
       }


### PR DESCRIPTION
This PR sets up a codebuild job in the deploy pipeline, to run after the e2e tests have finished, which generates more production-like data.

See also https://github.com/ministryofjustice/bichard7-next-ui/pull/174