### PR TITLE
Fix input artifacts to `seed-e2e-data` pipeline stage

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -337,7 +337,7 @@ resource "aws_codepipeline" "path_to_live" {
       version   = "1"
       run_order = 3
       configuration = {
-        ProjectName = module.seed_e2e_data.pipeline_name
+        ProjectName   = module.seed_e2e_data.pipeline_name
         PrimarySource = "ui-semaphore"
       }
 

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -338,13 +338,10 @@ resource "aws_codepipeline" "path_to_live" {
       run_order = 3
       configuration = {
         ProjectName   = module.seed_e2e_data.pipeline_name
-        PrimarySource = "ui-semaphore"
       }
 
       input_artifacts = [
-        "infrastructure",
-        "application-semaphore",
-        "ui-semaphore"
+        "infrastructure"
       ]
     }
 

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -172,6 +172,23 @@ resource "aws_codepipeline" "path_to_live" {
         DetectChanges        = false
       }
     }
+
+    action {
+      name             = "ui-source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["ui"]
+
+      configuration = {
+        ConnectionArn        = aws_codestarconnections_connection.github.arn
+        FullRepositoryId     = "ministryofjustice/bichard7-next-ui"
+        BranchName           = "main"
+        OutputArtifactFormat = "CODEBUILD_CLONE_REF"
+        DetectChanges        = false
+      }
+    }
   }
 
   stage {
@@ -340,7 +357,7 @@ resource "aws_codepipeline" "path_to_live" {
         ProjectName = module.seed_e2e_data.pipeline_name
       }
 
-      input_artifacts = ["tests"]
+      input_artifacts = ["ui"]
     }
 
     action {

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -337,7 +337,7 @@ resource "aws_codepipeline" "path_to_live" {
       version   = "1"
       run_order = 3
       configuration = {
-        ProjectName   = module.seed_e2e_data.pipeline_name
+        ProjectName = module.seed_e2e_data.pipeline_name
       }
 
       input_artifacts = [

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -338,11 +338,12 @@ resource "aws_codepipeline" "path_to_live" {
       run_order = 3
       configuration = {
         ProjectName = module.seed_e2e_data.pipeline_name
+        PrimarySource = "ui-semaphore"
       }
 
       input_artifacts = [
         "infrastructure",
-        "application",
+        "application-semaphore",
         "ui-semaphore"
       ]
     }

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -340,9 +340,7 @@ resource "aws_codepipeline" "path_to_live" {
         ProjectName = module.seed_e2e_data.pipeline_name
       }
 
-      input_artifacts = [
-        "infrastructure"
-      ]
+      input_artifacts = ["tests"]
     }
 
     action {

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live_iam.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live_iam.tf
@@ -54,6 +54,12 @@ resource "aws_iam_role_policy" "run_e2e_tests" {
   role   = module.run_e2e_tests.pipeline_service_role_name
 }
 
+resource "aws_iam_role_policy" "seed_e2e_data" {
+  name   = "allow-codestar-connection"
+  policy = data.template_file.allow_codebuild_codestar_connection.rendered
+  role   = module.seed_e2e_data.pipeline_service_role_name
+}
+
 resource "aws_iam_role_policy" "run_preprod_tests" {
   name   = "allow-codestar-connection"
   policy = data.template_file.allow_codebuild_codestar_connection.rendered


### PR DESCRIPTION
The UI repo has been added as a codestar github connection, and the repository is used as an input to the `seed-e2e-data` step