### PR TITLE
Deploy conductor JSON definitions as a step in the pipeline

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/build_e2e_test_environments.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_e2e_test_environments.tf
@@ -288,6 +288,69 @@ module "run_e2e_test_migrations" {
   tags = module.label.tags
 }
 
+module "deploy_conductor_definitions" {
+  source = "../modules/codebuild_job"
+
+  build_description      = "Codebuild job for updating JSON definitions for workflows, tasks and event listeners in Conductor"
+  codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
+  name                   = "deploy-conductor-definitions"
+  buildspec_file         = "buildspecs/deploy-conductor-definitions.yml"
+
+  repository_name      = "bichard7-next-infrastructure"
+  sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
+  sns_notification_arn = module.codebuild_base_resources.notifications_arn
+  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_block
+
+  build_timeout = 180
+
+  deploy_account_name = "integration_next"
+  deployment_name     = "e2e-test"
+
+  codebuild_secondary_sources = [
+    {
+      type              = "GITHUB"
+      location          = "https://github.com/ministryofjustice/bichard7-next-core.git"
+      git_clone_depth   = 1
+      source_identifier = "bichard7_next_core"
+      git_submodules_config = {
+        fetch_submodules = true
+      }
+    }
+  ]
+
+  environment_variables = [
+    {
+      name  = "DEPLOY_ENV"
+      value = "pathtolive"
+    },
+    {
+      name  = "WORKSPACE"
+      value = "e2e-test"
+    },
+    {
+      name  = "USER_TYPE"
+      value = "ci"
+    },
+    {
+      name  = "AWS_ACCOUNT_NAME"
+      value = "integration_next"
+    },
+    {
+      name  = "ASSUME_ROLE_ARN"
+      value = data.terraform_remote_state.shared_infra.outputs.integration_next_ci_arn
+    },
+    {
+      name  = "PARENT_ACCOUNT_ID"
+      value = data.aws_caller_identity.current.account_id
+    },
+    {
+      name  = "USE_PEERING"
+      value = "true"
+    },
+  ]
+  tags = module.label.tags
+}
+
 module "apply_dev_sg_to_e2e_test" {
   source = "../modules/codebuild_job"
 

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -156,6 +156,24 @@ resource "aws_codepipeline" "path_to_live" {
       }
     }
 
+    # Will be uncommented once the step has been tested outside of the pipeline
+    # action {
+    #   name             = "core-source"
+    #   category         = "Source"
+    #   owner            = "AWS"
+    #   provider         = "CodeStarSourceConnection"
+    #   version          = "1"
+    #   output_artifacts = ["core"]
+
+    #   configuration = {
+    #     ConnectionArn        = aws_codestarconnections_connection.github.arn
+    #     FullRepositoryId     = "ministryofjustice/bichard7-next-core"
+    #     BranchName           = "main"
+    #     OutputArtifactFormat = "CODEBUILD_CLONE_REF"
+    #     DetectChanges        = true
+    #   }
+    # }
+
     action {
       name             = "tests-source"
       category         = "Source"
@@ -305,6 +323,25 @@ resource "aws_codepipeline" "path_to_live" {
         "application"
       ]
     }
+
+    # Will be uncommented once the step has been tested outside of the pipeline
+    # action {
+    #   category = "Build"
+    #   name     = "deploy-conductor-definitions"
+    #   owner    = "AWS"
+    #   provider = "CodeBuild"
+    #   version  = "1"
+
+    #   configuration = {
+    #     ProjectName   = module.deploy_conductor_definitions.pipeline_name
+    #     PrimarySource = "infrastructure"
+    #   }
+
+    #   input_artifacts = [
+    #     "infrastructure",
+    #     "core"
+    #   ]
+    # }
   }
 
   stage {


### PR DESCRIPTION
This deploys the codebuild job but leaves the pipeline steps commented for now to avoid blocking things