### PR TITLE
Add verify e2e test ecs services to the pipeline

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -363,11 +363,42 @@ resource "aws_codepipeline" "path_to_live" {
 
     action {
       category  = "Build"
-      name      = "apply-dev-sgs-to-e2e-test"
+      name      = "verify-e2e-test-ecs-services"
       owner     = "AWS"
       provider  = "CodeBuild"
       version   = "1"
       run_order = 1
+
+      configuration = {
+        ProjectName   = module.verify_ecs_tasks.pipeline_name
+        PrimarySource = "infrastructure"
+
+        EnvironmentVariables = jsonencode(
+          [
+            {
+              name  = "ENVIRONMENT"
+              value = "e2e-test"
+            },
+            {
+              name  = "ASSUME_ROLE_ARN"
+              value = data.terraform_remote_state.shared_infra.outputs.integration_next_ci_arn
+            }
+          ]
+        )
+      }
+
+      input_artifacts = [
+        "infrastructure"
+      ]
+    }
+
+    action {
+      category  = "Build"
+      name      = "apply-dev-sgs-to-e2e-test"
+      owner     = "AWS"
+      provider  = "CodeBuild"
+      version   = "1"
+      run_order = 2
       configuration = {
         ProjectName = module.apply_dev_sg_to_e2e_test.pipeline_name
       }

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -412,7 +412,7 @@ resource "aws_codepipeline" "path_to_live" {
       owner     = "AWS"
       provider  = "CodeBuild"
       version   = "1"
-      run_order = 2
+      run_order = 3
       configuration = {
         ProjectName = module.run_e2e_tests.pipeline_name
         EnvironmentVariables = jsonencode(
@@ -434,7 +434,7 @@ resource "aws_codepipeline" "path_to_live" {
       owner     = "AWS"
       provider  = "CodeBuild"
       version   = "1"
-      run_order = 3
+      run_order = 4
       configuration = {
         ProjectName = module.seed_e2e_data.pipeline_name
       }
@@ -448,7 +448,7 @@ resource "aws_codepipeline" "path_to_live" {
       owner     = "AWS"
       provider  = "CodeBuild"
       version   = "1"
-      run_order = 4
+      run_order = 5
       configuration = {
         ProjectName = module.remove_dev_sg_from_e2e_test.pipeline_name
       }
@@ -657,7 +657,7 @@ resource "aws_codepipeline" "path_to_live" {
       owner     = "AWS"
       provider  = "CodeBuild"
       version   = "1"
-      run_order = 2
+      run_order = 3
 
       configuration = {
         ProjectName = module.run_preprod_tests.pipeline_name
@@ -672,7 +672,7 @@ resource "aws_codepipeline" "path_to_live" {
       owner     = "AWS"
       provider  = "CodeBuild"
       version   = "1"
-      run_order = 3
+      run_order = 4
 
       configuration = {
         ProjectName = module.remove_dev_sg_from_preprod.pipeline_name


### PR DESCRIPTION
Add verify e2e test ecs services to the pipeline and fix the run order of actions.