### PR TITLE
Upgrade Grafana db engine version in path to live to 13.8

### DIFF
--- a/terraform/modules/codebuild_monitoring/db.tf
+++ b/terraform/modules/codebuild_monitoring/db.tf
@@ -96,7 +96,7 @@ resource "aws_rds_cluster" "grafana_db" {
   enable_global_write_forwarding = false
 
   engine         = "aurora-postgresql"
-  engine_version = "13.4"
+  engine_version = "13.8"
 
   availability_zones = data.aws_availability_zones.current.names
   vpc_security_group_ids = [


### PR DESCRIPTION
Our Grafan database engine version in shared account has been upgraded (automatically) to 13.8.
This PR updates the version in our terraform code to match our AWS environment.