### PR TITLE
Removed miles from AWS

### DIFF
--- a/ansible/vars/users.yml
+++ b/ansible/vars/users.yml
@@ -36,8 +36,6 @@
       type: admin
     - name: hannah_goraya
       type: readonly
-    - name: miles_egbuchiem
-      type: readonly
 
 - users_removed:
     - name: tolu_johnson


### PR DESCRIPTION
There is uncertainty if designers need access to AWS, I'm just removing Miles for now and can revisit if there is a need later on down the line