### PR TITLE
Add core repo source to migrations cb jobs

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/build_e2e_test_environments.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_e2e_test_environments.tf
@@ -244,6 +244,15 @@ module "run_e2e_test_migrations" {
       git_submodules_config = {
         fetch_submodules = true
       }
+    },
+    {
+      type              = "GITHUB"
+      location          = "https://github.com/ministryofjustice/bichard7-next-core.git"
+      git_clone_depth   = 1
+      source_identifier = "bichard7_next_core"
+      git_submodules_config = {
+        fetch_submodules = true
+      }
     }
   ]
 

--- a/terraform/shared_account_pathtolive_infra_ci/build_load_test_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_load_test_environment.tf
@@ -273,6 +273,15 @@ module "run_load_test_migrations" {
       git_submodules_config = {
         fetch_submodules = true
       }
+    },
+    {
+      type              = "GITHUB"
+      location          = "https://github.com/ministryofjustice/bichard7-next-core.git"
+      git_clone_depth   = 1
+      source_identifier = "bichard7_next_core"
+      git_submodules_config = {
+        fetch_submodules = true
+      }
     }
   ]
 

--- a/terraform/shared_account_pathtolive_infra_ci/build_preprod.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_preprod.tf
@@ -379,6 +379,15 @@ module "run_preprod_migrations" {
       git_submodules_config = {
         fetch_submodules = true
       }
+    },
+    {
+      type              = "GITHUB"
+      location          = "https://github.com/ministryofjustice/bichard7-next-core.git"
+      git_clone_depth   = 1
+      source_identifier = "bichard7_next_core"
+      git_submodules_config = {
+        fetch_submodules = true
+      }
     }
   ]
 

--- a/terraform/shared_account_pathtolive_infra_ci/build_production.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_production.tf
@@ -494,6 +494,15 @@ module "run_production_migrations" {
       git_submodules_config = {
         fetch_submodules = true
       }
+    },
+    {
+      type              = "GITHUB"
+      location          = "https://github.com/ministryofjustice/bichard7-next-core.git"
+      git_clone_depth   = 1
+      source_identifier = "bichard7_next_core"
+      git_submodules_config = {
+        fetch_submodules = true
+      }
     }
   ]
 


### PR DESCRIPTION
This PR is to add `bichard7-next-core` source access to migrations Codebuild jobs. Once the pipeline is using the scripts in core to migrate and seed database, we can then remove the `bichard7-next` source from the migration Codebuild jobs.