### PR TITLE
Update specific codebuild jobs to use ci-admin user

### DIFF
--- a/applyci-access.yml
+++ b/applyci-access.yml
@@ -19,3 +19,4 @@ phases:
     commands:
       - set -e
       - CI_USER=true ./scripts/deploy_infra.sh
+...

--- a/applyci-access.yml
+++ b/applyci-access.yml
@@ -19,4 +19,3 @@ phases:
     commands:
       - set -e
       - CI_USER=true ./scripts/deploy_infra.sh
-...

--- a/applyci-buildspec.yml
+++ b/applyci-buildspec.yml
@@ -22,4 +22,3 @@ phases:
         cd terraform/shared_account_${ENVIRONMENT}_infra_ci
         TF_VAR_is_cd=true terraform init
         TF_VAR_is_cd=true terraform apply -auto-approve
-...

--- a/applyci-buildspec.yml
+++ b/applyci-buildspec.yml
@@ -2,13 +2,6 @@
 version: 0.2
 
 phases:
-  pre_build:
-    commands:
-      - echo "Elevating CI user credentials"
-      - |
-        aws iam attach-group-policy \
-          --group-name "CIAccess" \
-          --policy-arn "arn:aws:iam::aws:policy/AdministratorAccess"
   install:
     commands:
       - |
@@ -26,15 +19,7 @@ phases:
     commands:
       - set -e
       - |
-        echo "Waiting 120 seconds for IAM permissions to apply"
-        sleep 120
         cd terraform/shared_account_${ENVIRONMENT}_infra_ci
         TF_VAR_is_cd=true terraform init
         TF_VAR_is_cd=true terraform apply -auto-approve
-  post_build:
-    commands:
-      - echo "Removing CI user credentials elevation"
-      - |
-        aws iam detach-group-policy \
-          --group-name "CIAccess" \
-          --policy-arn "arn:aws:iam::aws:policy/AdministratorAccess"
+...

--- a/applyci-monitoring.yml
+++ b/applyci-monitoring.yml
@@ -1,5 +1,4 @@
 ---
-
 version: 0.2
 
 phases:
@@ -10,4 +9,3 @@ phases:
         cd terraform/shared_account_pathtolive_infra_ci_monitoring
         TF_VAR_is_cd=true terraform init
         TF_VAR_is_cd=true terraform apply -auto-approve
-...

--- a/applyci-monitoring.yml
+++ b/applyci-monitoring.yml
@@ -3,27 +3,11 @@
 version: 0.2
 
 phases:
-  pre_build:
-    commands:
-      - echo "Elevating CI user credentials"
-      - |
-        aws iam attach-group-policy \
-          --group-name "CIAccess" \
-          --policy-arn "arn:aws:iam::aws:policy/AdministratorAccess"
   build:
     commands:
       - set -e
       - |
-        echo "Waiting 30 seconds for IAM permissions to apply"
-        sleep 30
         cd terraform/shared_account_pathtolive_infra_ci_monitoring
         TF_VAR_is_cd=true terraform init
         TF_VAR_is_cd=true terraform apply -auto-approve
-  post_build:
-    commands:
-      - echo "Removing CI user credentials elevation"
-      - |
-        aws iam detach-group-policy \
-          --group-name "CIAccess" \
-          --policy-arn "arn:aws:iam::aws:policy/AdministratorAccess"
 ...

--- a/manage-users-buildspec.yml
+++ b/manage-users-buildspec.yml
@@ -6,25 +6,8 @@ phases:
   install:
     runtime-versions:
       python: 3.9
-  pre_build:
-    commands:
-      - echo "Elevating CI user credentials"
-      - |
-        aws iam attach-group-policy \
-          --group-name "CIAccess" \
-          --policy-arn "arn:aws:iam::aws:policy/AdministratorAccess"
   build:
     commands:
       - set -e
-      - |
-        echo "Waiting 30 seconds for IAM permissions to apply"
-        sleep 30
       - ./scripts/manage_users.sh
-  post_build:
-    commands:
-      - echo "Removing CI user credentials elevation"
-      - |
-        aws iam detach-group-policy \
-          --group-name "CIAccess" \
-          --policy-arn "arn:aws:iam::aws:policy/AdministratorAccess"
 ...

--- a/manage-users-buildspec.yml
+++ b/manage-users-buildspec.yml
@@ -1,5 +1,4 @@
 ---
-
 version: 0.2
 
 phases:
@@ -10,4 +9,3 @@ phases:
     commands:
       - set -e
       - ./scripts/manage_users.sh
-...

--- a/terraform/modules/shared_cd_common_jobs/cd_layer.tf
+++ b/terraform/modules/shared_cd_common_jobs/cd_layer.tf
@@ -1,12 +1,14 @@
 module "apply_codebuild_layer" {
-  source                 = "../codebuild_job"
-  build_description      = "Apply the shared account ci layer on a schedule"
-  codepipeline_s3_bucket = var.codebuild_s3_bucket
-  name                   = "apply-codebuild-layer"
-  sns_kms_key_arn        = var.notifications_kms_key_arn
-  sns_notification_arn   = var.sns_notifications_arn
-  repository_name        = "bichard7-next-shared-infrastructure"
-  buildspec_file         = "applyci-buildspec.yml"
+  source                         = "../codebuild_job"
+  build_description              = "Apply the shared account ci layer on a schedule"
+  codepipeline_s3_bucket         = var.codebuild_s3_bucket
+  name                           = "apply-codebuild-layer"
+  sns_kms_key_arn                = var.notifications_kms_key_arn
+  sns_notification_arn           = var.sns_notifications_arn
+  repository_name                = "bichard7-next-shared-infrastructure"
+  buildspec_file                 = "applyci-buildspec.yml"
+  aws_access_key_id_ssm_path     = "/ci-admin/user/access_key_id"
+  aws_secret_access_key_ssm_path = "/ci-admin/user/secret_access_key"
 
   environment_variables = [
     {

--- a/terraform/modules/shared_cd_common_jobs/manage_aws_users.tf
+++ b/terraform/modules/shared_cd_common_jobs/manage_aws_users.tf
@@ -1,12 +1,14 @@
 module "manage_aws_users" {
-  source                 = "../codebuild_job"
-  build_description      = "Run user management jobs on a schedule"
-  codepipeline_s3_bucket = var.codebuild_s3_bucket
-  name                   = "manage-aws-users"
-  sns_kms_key_arn        = var.notifications_kms_key_arn
-  sns_notification_arn   = var.sns_notifications_arn
-  repository_name        = "bichard7-next-shared-infrastructure"
-  buildspec_file         = "manage-users-buildspec.yml"
+  source                         = "../codebuild_job"
+  build_description              = "Run user management jobs on a schedule"
+  codepipeline_s3_bucket         = var.codebuild_s3_bucket
+  name                           = "manage-aws-users"
+  sns_kms_key_arn                = var.notifications_kms_key_arn
+  sns_notification_arn           = var.sns_notifications_arn
+  repository_name                = "bichard7-next-shared-infrastructure"
+  buildspec_file                 = "manage-users-buildspec.yml"
+  aws_access_key_id_ssm_path     = "/ci-admin/user/access_key_id"
+  aws_secret_access_key_ssm_path = "/ci-admin/user/secret_access_key"
 
   environment_variables = [
     {

--- a/terraform/shared_account_pathtolive_infra_ci/ci_monitoring.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/ci_monitoring.tf
@@ -1,10 +1,12 @@
 module "build_ci_monitoring" {
   source = "../modules/codebuild_job"
 
-  name              = "apply-ci-monitoring-layer"
-  build_description = "Apply our CI Monitoring Layer"
-  repository_name   = "bichard7-next-shared-infrastructure"
-  buildspec_file    = "applyci-monitoring.yml"
+  name                           = "apply-ci-monitoring-layer"
+  build_description              = "Apply our CI Monitoring Layer"
+  repository_name                = "bichard7-next-shared-infrastructure"
+  buildspec_file                 = "applyci-monitoring.yml"
+  aws_access_key_id_ssm_path     = "/ci-admin/user/access_key_id"
+  aws_secret_access_key_ssm_path = "/ci-admin/user/secret_access_key"
 
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   sns_notification_arn   = module.codebuild_base_resources.notifications_arn


### PR DESCRIPTION
This PR updates the below CodeBuild jobs to use the `ci-admin` user instead of the default `ci` user. Previously, these jobs used the default `ci` user and attached the admin group to be able to apply the Terraform changes. However, given that other CodeBuild jobs shared the same ci user, all jobs had admin access during the execution of these specific jobs, causing security issues. Additionally, these jobs were random failing because attaching the admin group to a user could take some time, leading to instances where the admin group was not applied to the user on time.

Codebuild jobs updated:
- `apply-ci-monitoring-layer`
- `apply-codebuild-layer`
- `manage-aws-users`