### PR TITLE
Add CI admin role to CI access role trust policy

### DIFF
--- a/terraform/modules/shared_account_child_access/data.tf
+++ b/terraform/modules/shared_account_child_access/data.tf
@@ -37,12 +37,13 @@ data "template_file" "deny_ci_permissions_policy" {
 }
 
 data "template_file" "allow_assume_ci_access_template" {
-  template = file("${path.module}/policies/${local.no_mfa_access_template}")
+  template = file("${path.module}/policies/${local.no_mfa_multi_user_roles_access_template}")
 
   vars = {
     parent_account_id = var.root_account_id
     excluded_arns     = jsonencode(var.denied_user_arns)
     user_role         = "ci/cd"
+    admin_user_role   = "ci-admin"
   }
 }
 

--- a/terraform/modules/shared_account_child_access/locals.tf
+++ b/terraform/modules/shared_account_child_access/locals.tf
@@ -1,4 +1,5 @@
 locals {
-  access_template        = (length(var.denied_user_arns) > 0) ? "allow_assume_role_with_deny.json.tpl" : "allow_assume_role.json.tpl"
-  no_mfa_access_template = (length(var.denied_user_arns) > 0) ? "allow_assume_role_with_deny_no_mfa.json.tpl" : "allow_assume_role_no_mfa.json.tpl"
+  access_template                         = (length(var.denied_user_arns) > 0) ? "allow_assume_role_with_deny.json.tpl" : "allow_assume_role.json.tpl"
+  no_mfa_access_template                  = (length(var.denied_user_arns) > 0) ? "allow_assume_role_with_deny_no_mfa.json.tpl" : "allow_assume_role_no_mfa.json.tpl"
+  no_mfa_multi_user_roles_access_template = (length(var.denied_user_arns) > 0) ? "allow_assume_role_with_deny_no_mfa_multi_user_roles.json.tpl" : "allow_assume_role_no_mfa_multi_user_roles.json.tpl"
 }

--- a/terraform/modules/shared_account_child_access/policies/allow_assume_role_no_mfa_multi_user_roles.json.tpl
+++ b/terraform/modules/shared_account_child_access/policies/allow_assume_role_no_mfa_multi_user_roles.json.tpl
@@ -1,0 +1,29 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${parent_account_id}:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals" : {
+          "aws:PrincipalTag/user-role": "${user_role}"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${parent_account_id}:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals" : {
+          "aws:PrincipalTag/user-role": "${admin_user_role}"
+        }
+      }
+    }
+  ]
+}

--- a/terraform/modules/shared_account_child_access/policies/allow_assume_role_with_deny_no_mfa_multi_user_roles.json.tpl
+++ b/terraform/modules/shared_account_child_access/policies/allow_assume_role_with_deny_no_mfa_multi_user_roles.json.tpl
@@ -1,0 +1,35 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${parent_account_id}:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "ArnNotEquals" : {
+          "aws:PrincipalArn" : ${excluded_arns}
+        },
+        "StringEquals" : {
+          "aws:PrincipalTag/user-role": "${user_role}"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${parent_account_id}:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "ArnNotEquals" : {
+          "aws:PrincipalArn" : ${excluded_arns}
+        },
+        "StringEquals" : {
+          "aws:PrincipalTag/user-role": "${admin_user_role}"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds `ci-admin` role to `Bichard7-CI-Access` role trust policy in child accounts. This will allow our ci-admin user to assume the CI access role.