### PR TITLE
Change timeout for ECR queries to 10s

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci_monitoring/ecr_alarms.tf
+++ b/terraform/shared_account_pathtolive_infra_ci_monitoring/ecr_alarms.tf
@@ -95,7 +95,7 @@ resource "aws_lambda_function" "query_images_fn" {
   role        = aws_iam_role.ecr_repo_images.arn
   memory_size = "128"
   runtime     = "python3.8"
-  timeout     = "5"
+  timeout     = "10"
 
   tags = module.label.tags
 }


### PR DESCRIPTION
The lambda recurses through the repositories we have and initiates quite a few queries, which averages (by eye) around 4.4 seconds at the moment. Changing the timeout to 10 seconds will reduce alert noise for a bit, once it gets to 10s we should probably look at optimising the query.