### PR TITLE
Removed redundant users in users.yml

### DIFF
--- a/ansible/vars/users.yml
+++ b/ansible/vars/users.yml
@@ -34,24 +34,3 @@
       type: admin
 
 - users_removed:
-    - name: tolu_johnson
-    - name: christopher_ryan
-    - name: david_roberts
-    - name: gurpinder_basi
-    - name: iain_smart
-    - name: sam_slade
-    - name: samuel_blackwell
-    - name: satvinder_hullait
-    - name: brett_minnie
-    - name: mihai_popa_matai
-    - name: heather_roberts
-    - name: tom_vaughan
-    - name: simon_oldham
-    - name: jazz_sarkaria
-    - name: jess_neely
-    - name: comfort_osobu
-    - name: agnieszka_zbikowska
-    - name: hannah_goraya
-    - name: jamie_davies
-    - name: donny_hyon
-    - name: csaba_gyorfi


### PR DESCRIPTION
This just cleans up the list of team members who have left Bichard

![image](https://github.com/ministryofjustice/bichard7-next-shared-infrastructure/assets/65510707/4c051fb3-c229-476a-98b6-7e4f166c34db)
