### PR TITLE
Set cron job to run daily instead of every monday

### DIFF
--- a/terraform/modules/shared_cd_common_jobs/build_offline_binaries.tf
+++ b/terraform/modules/shared_cd_common_jobs/build_offline_binaries.tf
@@ -62,7 +62,7 @@ module "trivy_scan" {
 module "trivy_scan_trigger" {
   source          = "../codebuild_schedule"
   codebuild_arn   = module.trivy_scan.pipeline_arn
-  cron_expression = "cron(0 10 ? * MON *)"
+  cron_expression = "cron(0 10 ? * * *)"
   name            = module.trivy_scan.pipeline_name
 
   tags = var.tags


### PR DESCRIPTION
This PR changes the `trivy-scan-containers` codebuild to run daily instead of every Monday