### PR TITLE
Remove E2E tests CodeBuild job schedule and webhook

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
@@ -55,43 +55,6 @@ module "run_e2e_tests" {
   ]
 }
 
-resource "aws_codebuild_webhook" "e2e_tests_pr_webhook" {
-  project_name = module.run_e2e_tests.pipeline_name
-
-  # Run the tests when a PR is created or updated and is not the master branch
-  filter_group {
-    filter {
-      type    = "EVENT"
-      pattern = "PULL_REQUEST_CREATED"
-    }
-
-    filter {
-      type    = "EVENT"
-      pattern = "PULL_REQUEST_UPDATED"
-    }
-
-    filter {
-      type                    = "HEAD_REF"
-      pattern                 = "refs/heads/main"
-      exclude_matched_pattern = true
-    }
-  }
-
-  # Run the tests when the master branch is updated from a merge or a naughty force push
-  filter_group {
-    filter {
-      type    = "EVENT"
-      pattern = "PUSH"
-    }
-
-    filter {
-      type    = "HEAD_REF"
-      pattern = "refs/heads/main"
-    }
-  }
-
-}
-
 module "run_e2e_tests_restart_pnc_container" {
   source            = "../modules/codebuild_job"
   name              = "restart-e2e-test-pnc-emulator-container"

--- a/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
@@ -55,16 +55,6 @@ module "run_e2e_tests" {
   ]
 }
 
-module "run_e2e_tests_schedule" {
-  count           = 0 // We are disabling this for now as it interferes with the pipeline testing, we'll probably remove it
-  source          = "../modules/codebuild_schedule"
-  codebuild_arn   = module.run_e2e_tests.pipeline_arn
-  name            = module.run_e2e_tests.pipeline_name
-  cron_expression = "cron(30 8-18 ? * MON-FRI *)"
-
-  tags = module.label.tags
-}
-
 resource "aws_codebuild_webhook" "e2e_tests_pr_webhook" {
   project_name = module.run_e2e_tests.pipeline_name
 


### PR DESCRIPTION
## Context

We run the E2E tests as part of our deployment pipeline so there's no value in running it when we merge into main. The CodeBuild job schedule is also unused.


## Changes proposed in this PR

Remove E2E tests CodeBuild job schedule and webhook.