### PR TITLE
Firebreak: Add codebuild job to run UAT seed script

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -502,7 +502,7 @@ module "seed_uat_environment" {
 
   build_description      = "Insert test data into UAT environment"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
-  name                   = "deploy-uat"
+  name                   = "seed-uat"
   sns_kms_key_arn        = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn   = module.codebuild_base_resources.notifications_arn
   vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -495,7 +495,7 @@ module "remove_dev_sg_from_uat" {
 }
 
 module "seed_uat_environment" {
-  source = "../codebuild_job"
+  source = "../modules/codebuild_job"
 
   repository_name = "bichard7-next-core"
   buildspec_file  = "packages/uat-data/buildspec.yml"
@@ -506,6 +506,7 @@ module "seed_uat_environment" {
   sns_kms_key_arn        = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn   = module.codebuild_base_resources.notifications_arn
   vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  tags = module.label.tags
 }
 
 module "apply_codebuild_layer_schedule" {

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -524,6 +524,14 @@ module "seed_uat_environment" {
     {
       name = "PNC_PORT"
       value = "3000"
+    },
+    {
+      name  = "AWS_ACCOUNT_NAME"
+      value = "integration_baseline"
+    },
+    {
+      name  = "ASSUME_ROLE_ARN"
+      value = data.terraform_remote_state.shared_infra.outputs.integration_baseline_ci_arn
     }
   ]
 }

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -509,9 +509,9 @@ module "seed_uat_environment" {
 }
 
 module "apply_codebuild_layer_schedule" {
-  source          = "../codebuild_schedule"
+  source          = "../modules/codebuild_schedule"
   codebuild_arn   = module.apply_codebuild_layer.pipeline_arn
   name            = module.apply_codebuild_layer.pipeline_name
   cron_expression = "cron(0 0 * * ? *)"
-  tags            = var.tags
+  tags            = module.tag_vars
 }

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -507,6 +507,13 @@ module "seed_uat_environment" {
   sns_notification_arn   = module.codebuild_base_resources.notifications_arn
   vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
   tags                   = module.label.tags
+
+    environment_variables = [
+    {
+      name  = "S3_INCOMING_MESSAGE_BUCKET"
+      value = "bichard-7-uat-incoming-messages"
+    }
+  ]
 }
 
 module "apply_codebuild_layer_schedule" {

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -534,18 +534,6 @@ module "seed_uat_environment" {
       value = data.terraform_remote_state.shared_infra.outputs.integration_baseline_ci_arn
     }
   ]
-
-  codebuild_secondary_sources = [
-    {
-      type              = "GITHUB"
-      location          = "https://github.com/ministryofjustice/bichard7-next-infrastructure.git"
-      git_clone_depth   = 1
-      source_identifier = "bichard7_next_infrastructure"
-      git_submodules_config = {
-        fetch_submodules = true
-      }
-    }
-  ]
 }
 
 module "apply_codebuild_layer_schedule" {

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -508,6 +508,10 @@ module "seed_uat_environment" {
   vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
   tags                   = module.label.tags
 
+  allowed_resource_arns = [
+    data.aws_ecr_repository.codebuild_base.arn
+  ]
+
   build_environments = local.pipeline_build_environments
 
   environment_variables = [

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -506,13 +506,13 @@ module "seed_uat_environment" {
   sns_kms_key_arn        = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn   = module.codebuild_base_resources.notifications_arn
   vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
-  tags = module.label.tags
+  tags                   = module.label.tags
 }
 
 module "apply_codebuild_layer_schedule" {
   source          = "../modules/codebuild_schedule"
-  codebuild_arn   = module.apply_codebuild_layer.pipeline_arn
-  name            = module.apply_codebuild_layer.pipeline_name
+  codebuild_arn   = module.seed_uat_environment.pipeline_arn
+  name            = module.seed_uat_environment.pipeline_name
   cron_expression = "cron(0 0 * * ? *)"
   tags            = module.tag_vars
 }

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -556,6 +556,6 @@ module "apply_codebuild_layer_schedule" {
   source          = "../modules/codebuild_schedule"
   codebuild_arn   = module.seed_uat_environment.pipeline_arn
   name            = module.seed_uat_environment.pipeline_name
-  cron_expression = "cron(0 0 * * ? *)"
+  cron_expression = "cron(0 0,8,16 * * ? *)"
   tags            = module.tag_vars
 }

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -514,11 +514,19 @@ module "seed_uat_environment" {
       value = "bichard-7-uat-incoming-messages"
     },
     {
-      name  = "PNC_HOST"
-      value = "cjse-uat-bichard-7-pnc-emulator-75e8686f94f102b8.elb.eu-west-2.amazonaws.co"
+      name  = "WORKSPACE"
+      value = "uat"
     },
     {
-      name  = "PNC_PORT"
+      name  = "USE_PEERING"
+      value = "true"
+    },
+    {
+      name = "PNC_HOST"
+      value = "cjse-uat-bichard-7-pnc-emulator-75e8686f94f102b8.elb.eu-west-2.amazonaws.com"
+    },
+    {
+      name = "PNC_PORT"
       value = "3000"
     }
   ]

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -512,6 +512,14 @@ module "seed_uat_environment" {
     {
       name  = "S3_INCOMING_MESSAGE_BUCKET"
       value = "bichard-7-uat-incoming-messages"
+    },
+    {
+      name  = "PNC_HOST"
+      value = "cjse-uat-bichard-7-pnc-emulator-75e8686f94f102b8.elb.eu-west-2.amazonaws.co"
+    },
+    {
+      name  = "PNC_PORT"
+      value = "3000"
     }
   ]
 }

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -495,10 +495,10 @@ module "remove_dev_sg_from_uat" {
 }
 
 module "seed_uat_environment" {
-  source                         = "../codebuild_job"
+  source = "../codebuild_job"
 
-  repository_name                = "bichard7-next-core"
-  buildspec_file                 = "packages/uat-data/buildspec.yml"
+  repository_name = "bichard7-next-core"
+  buildspec_file  = "packages/uat-data/buildspec.yml"
 
   build_description      = "Insert test data into UAT environment"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -508,7 +508,18 @@ module "seed_uat_environment" {
   vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
   tags                   = module.label.tags
 
-    environment_variables = [
+  build_environments = [
+    {
+      compute_type                = "BUILD_GENERAL1_MEDIUM"
+      type                        = "LINUX_CONTAINER"
+      privileged_mode             = true
+      image                       = "aws/codebuild/amazonlinux-x86_64-standard:5.0"
+      image_pull_credentials_type = "SERVICE_ROLE"
+
+    }
+  ]
+
+  environment_variables = [
     {
       name  = "S3_INCOMING_MESSAGE_BUCKET"
       value = "bichard-7-uat-incoming-messages"
@@ -518,11 +529,11 @@ module "seed_uat_environment" {
       value = "uat"
     },
     {
-      name = "PNC_HOST"
+      name  = "PNC_HOST"
       value = "cjse-uat-bichard-7-pnc-emulator-75e8686f94f102b8.elb.eu-west-2.amazonaws.com"
     },
     {
-      name = "PNC_PORT"
+      name  = "PNC_PORT"
       value = "3000"
     },
     {

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -493,3 +493,25 @@ module "remove_dev_sg_from_uat" {
 
   tags = module.label.tags
 }
+
+module "seed_uat_environment" {
+  source                         = "../codebuild_job"
+
+  repository_name                = "bichard7-next-core"
+  buildspec_file                 = "packages/uat-data/buildspec.yml"
+
+  build_description      = "Insert test data into UAT environment"
+  codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
+  name                   = "deploy-uat"
+  sns_kms_key_arn        = module.codebuild_base_resources.notifications_kms_key_arn
+  sns_notification_arn   = module.codebuild_base_resources.notifications_arn
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+}
+
+module "apply_codebuild_layer_schedule" {
+  source          = "../codebuild_schedule"
+  codebuild_arn   = module.apply_codebuild_layer.pipeline_arn
+  name            = module.apply_codebuild_layer.pipeline_name
+  cron_expression = "cron(0 0 * * ? *)"
+  tags            = var.tags
+}

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -509,6 +509,26 @@ module "seed_uat_environment" {
 
   environment_variables = [
     {
+      name  = "PNC_HOST"
+      value = "pnc.uat.ptl.bichard7.modernisation-platform.service.justice.gov.uk"
+    },
+    {
+      name  = "PNC_PORT"
+      value = "3000"
+    },
+    {
+      name  = "S3_INCOMING_MESSAGE_BUCKET"
+      value = "bichard-7-uat-incoming-messages"
+    },
+    {
+      name  = "DEPLOY_NAME"
+      value = "uat"
+    },
+    {
+      name  = "REPEAT_SCENARIOS"
+      value = "10"
+    },
+    {
       name  = "DEPLOY_ENV"
       value = "pathtolive"
     },
@@ -525,20 +545,8 @@ module "seed_uat_environment" {
       value = "integration_baseline"
     },
     {
-      name  = "AUTO_APPROVE"
-      value = true
-    },
-    {
       name  = "ASSUME_ROLE_ARN"
       value = data.terraform_remote_state.shared_infra.outputs.integration_baseline_ci_arn
-    },
-    {
-      name  = "PARENT_ACCOUNT_ID"
-      value = data.aws_caller_identity.current.account_id
-    },
-    {
-      name  = "LIQUIBASE_IMAGE"
-      value = local.latest_liquibase_image
     }
   ]
   tags = module.label.tags

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -518,10 +518,6 @@ module "seed_uat_environment" {
       value = "uat"
     },
     {
-      name  = "USE_PEERING"
-      value = "true"
-    },
-    {
       name = "PNC_HOST"
       value = "cjse-uat-bichard-7-pnc-emulator-75e8686f94f102b8.elb.eu-west-2.amazonaws.com"
     },

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -534,6 +534,18 @@ module "seed_uat_environment" {
       value = data.terraform_remote_state.shared_infra.outputs.integration_baseline_ci_arn
     }
   ]
+
+  codebuild_secondary_sources = [
+    {
+      type              = "GITHUB"
+      location          = "https://github.com/ministryofjustice/bichard7-next-infrastructure.git"
+      git_clone_depth   = 1
+      source_identifier = "bichard7_next_infrastructure"
+      git_submodules_config = {
+        fetch_submodules = true
+      }
+    }
+  ]
 }
 
 module "apply_codebuild_layer_schedule" {

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -508,16 +508,7 @@ module "seed_uat_environment" {
   vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
   tags                   = module.label.tags
 
-  build_environments = [
-    {
-      compute_type                = "BUILD_GENERAL1_MEDIUM"
-      type                        = "LINUX_CONTAINER"
-      privileged_mode             = true
-      image                       = "aws/codebuild/amazonlinux-x86_64-standard:5.0"
-      image_pull_credentials_type = "SERVICE_ROLE"
-
-    }
-  ]
+  build_environments = local.pipeline_build_environments
 
   environment_variables = [
     {


### PR DESCRIPTION
This PR adds a codebuild job to the shared account. It references the buildspec in `core/packages/uat-data`, and adds a cron trigger to run at 00:00, 08:00 and 14:00 daily. 

Each time it runs, it will upload 10 versions of each trigger UAT Bichard.