### PR TITLE
Update VPC configs for unique CodeBuild jobs by environment

### DIFF
--- a/terraform/modules/codebuild_base_resources/locals.tf
+++ b/terraform/modules/codebuild_base_resources/locals.tf
@@ -3,4 +3,18 @@ locals {
     region     = data.aws_region.current.name
     account_id = data.aws_caller_identity.current.account_id
   })
+
+  codebuild_vpc_config_blocks = { for env, sg in aws_security_group.environment_codebuild_vpc_sgs : env =>
+    [
+      {
+        vpc_id  = module.vpc.vpc_id
+        subnets = module.vpc.private_subnets
+        security_group_ids = [
+          module.vpc.default_security_group_id,
+          aws_security_group.codebuild_vpc_sg.id,
+          sg.id
+        ]
+      }
+    ]
+  }
 }

--- a/terraform/modules/codebuild_base_resources/outputs.tf
+++ b/terraform/modules/codebuild_base_resources/outputs.tf
@@ -71,6 +71,11 @@ output "codebuild_security_group_id" {
   value       = aws_security_group.codebuild_vpc_sg.id
 }
 
+output "codebuild_security_group_ids" {
+  description = "Mapping of environment names to their security group IDs"
+  value       = { for env, sg in aws_security_group.environment_codebuild_vpc_sgs : env => sg.id }
+}
+
 output "codebuild_vpc_config_block" {
   description = "A preformed config block to pass to codebuild"
   value = [
@@ -83,6 +88,11 @@ output "codebuild_vpc_config_block" {
       ]
     }
   ]
+}
+
+output "codebuild_vpc_config_blocks" {
+  description = "A preformed config block to pass to codebuild"
+  value       = local.codebuild_vpc_config_blocks
 }
 
 output "codebuild_cidr_block" {

--- a/terraform/modules/codebuild_base_resources/variables.tf
+++ b/terraform/modules/codebuild_base_resources/variables.tf
@@ -41,6 +41,12 @@ variable "vpc_cidr_block" {
   default     = null
 }
 
+variable "codebuild_sg_environment_names" {
+  description = "List of environment names for CodeBuild security groups"
+  type        = set(string)
+  default     = []
+}
+
 variable "is_sandbox_account" {
   description = "Is this a sandbox account?"
   type        = bool

--- a/terraform/modules/codebuild_base_resources/vpc_codebuild_sgs.tf
+++ b/terraform/modules/codebuild_base_resources/vpc_codebuild_sgs.tf
@@ -1,0 +1,138 @@
+resource "aws_security_group" "environment_codebuild_vpc_sgs" {
+  for_each = var.codebuild_sg_environment_names
+
+  description = "${each.value} Codebuild jobs SG for our VPC"
+  name_prefix = "${var.name}-${each.value}"
+
+  vpc_id = module.vpc.vpc_id
+  tags = merge(
+    var.tags,
+    {
+      name = "${var.name}-${each.value}-codebuild-vpc"
+    }
+  )
+}
+
+# tfsec:ignore:aws-vpc-no-public-egress-sgr
+resource "aws_security_group_rule" "codebuild_egress_to_all_github_ssl" {
+  for_each = aws_security_group.environment_codebuild_vpc_sgs
+
+  description = "Allow outbound ssl traffic"
+
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+  type      = "egress"
+
+  security_group_id = each.value.id
+  cidr_blocks       = ["0.0.0.0/0"] # tfsec:ignore:AWS007
+}
+
+# tfsec:ignore:aws-vpc-no-public-egress-sgr
+resource "aws_security_group_rule" "codebuild_egress_to_all_github_ssh" {
+  for_each = aws_security_group.environment_codebuild_vpc_sgs
+
+  description = "Allow outbound ssh traffic"
+
+  from_port = 22
+  to_port   = 22
+  protocol  = "tcp"
+  type      = "egress"
+
+  security_group_id = each.value.id
+  cidr_blocks       = ["0.0.0.0/0"] # tfsec:ignore:AWS007
+}
+
+# tfsec:ignore:aws-vpc-no-public-egress-sgr
+resource "aws_security_group_rule" "codebuild_egress_to_all_github_http" {
+  for_each = aws_security_group.environment_codebuild_vpc_sgs
+
+  description = "Allow outbound http traffic"
+
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+  type      = "egress"
+
+  security_group_id = each.value.id
+  cidr_blocks       = ["0.0.0.0/0"] # tfsec:ignore:AWS007
+}
+
+# tfsec:ignore:aws-vpc-no-public-egress-sgr
+resource "aws_security_group_rule" "codebuild_egress_to_all_github_git" {
+  for_each = aws_security_group.environment_codebuild_vpc_sgs
+
+  description = "Allow outbound git traffic"
+
+  from_port = 9418
+  to_port   = 9418
+  protocol  = "tcp"
+  type      = "egress"
+
+  security_group_id = each.value.id
+  cidr_blocks       = ["0.0.0.0/0"] # tfsec:ignore:AWS007
+}
+
+# tfsec:ignore:aws-vpc-no-public-egress-sgr
+resource "aws_security_group_rule" "codebuild_egress_to_gpg_server" {
+  for_each = aws_security_group.environment_codebuild_vpc_sgs
+
+  description = "Allow outbound gpg server traffic"
+
+  from_port = 11371
+  to_port   = 11371
+  protocol  = "tcp"
+  type      = "egress"
+
+  security_group_id = each.value.id
+  cidr_blocks       = ["0.0.0.0/0"] # tfsec:ignore:AWS007
+}
+
+# tfsec:ignore:aws-vpc-no-public-ingress-sgr
+resource "aws_security_group_rule" "codebuild_ingress_from_github_http" {
+  for_each = aws_security_group.environment_codebuild_vpc_sgs
+
+  description = "Allow http traffic from github to ingress"
+
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+  type      = "ingress"
+
+  security_group_id = each.value.id
+  # Hook cidrs defined in https://api.github.com/meta
+  cidr_blocks = [
+    "192.30.252.0/22",
+    "185.199.108.0/22",
+    "140.82.112.0/20",
+    "143.55.64.0/20"
+  ]
+}
+
+# tfsec:ignore:aws-vpc-no-public-ingress-sgr
+resource "aws_security_group_rule" "codebuild_ingress_from_github_ssl" {
+  for_each = aws_security_group.environment_codebuild_vpc_sgs
+
+  description = "Allow outbound ssl traffic"
+
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+  type      = "ingress"
+
+  security_group_id = each.value.id
+  # Hook cidrs defined in https://api.github.com/meta
+  cidr_blocks = [
+    "192.30.252.0/22",
+    "185.199.108.0/22",
+    "140.82.112.0/20",
+    "143.55.64.0/20",
+  ]
+}
+
+resource "aws_vpc_endpoint_security_group_association" "codepipeline_vpce_codebuild_sgs" {
+  for_each = aws_security_group.environment_codebuild_vpc_sgs
+
+  vpc_endpoint_id   = resource.aws_vpc_endpoint.codepipeline_vpc_endpoint.id
+  security_group_id = each.value.id
+}

--- a/terraform/shared_account_pathtolive_infra_ci/build_e2e_test_environments.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_e2e_test_environments.tf
@@ -8,7 +8,7 @@ module "deploy_e2e_test_terraform" {
   buildspec_file         = "buildspecs/buildspec.yml"
   sns_kms_key_arn        = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn   = module.codebuild_base_resources.notifications_arn
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["e2e-test"]
 
   build_timeout = 180
 
@@ -132,7 +132,7 @@ module "destroy_e2e_test_terraform" {
   repository_name      = "bichard7-next-infrastructure"
   sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn = module.codebuild_base_resources.notifications_arn
-  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_blocks["e2e-test"]
 
   build_timeout = 180
 
@@ -226,7 +226,7 @@ module "run_e2e_test_migrations" {
   repository_name      = "bichard7-next-infrastructure"
   sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn = module.codebuild_base_resources.notifications_arn
-  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_blocks["e2e-test"]
 
   build_timeout = 180
 
@@ -306,7 +306,7 @@ module "deploy_e2e_test_conductor_definitions" {
   repository_name      = "bichard7-next-infrastructure"
   sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn = module.codebuild_base_resources.notifications_arn
-  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_blocks["e2e-test"]
 
   build_timeout = 180
 
@@ -364,7 +364,7 @@ module "apply_dev_sg_to_e2e_test" {
   build_description      = "Codebuild Pipeline for rebuilding terraform infrastructure"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "apply-dev-sgs-to-e2e-test"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["e2e-test"]
 
   buildspec_file       = "buildspecs/vpc-sg-access.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -418,7 +418,7 @@ module "remove_dev_sg_from_e2e_test" {
   build_description      = "Codebuild Pipeline for rebuilding terraform infrastructure"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "remove-dev-sgs-from-e2e-test"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["e2e-test"]
 
   buildspec_file       = "buildspecs/vpc-sg-access.yml"
   repository_name      = "bichard7-next-infrastructure"

--- a/terraform/shared_account_pathtolive_infra_ci/build_load_test_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_load_test_environment.tf
@@ -7,7 +7,7 @@ module "deploy_load_test_terraform" {
   repository_name        = "bichard7-next-infrastructure"
   sns_kms_key_arn        = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn   = module.codebuild_base_resources.notifications_arn
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["uat"]
   buildspec_file         = "buildspecs/buildspec.yml"
 
   build_timeout = 180
@@ -151,7 +151,7 @@ module "destroy_load_test_terraform" {
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "destroy-integration-baseline-load-test"
   buildspec_file         = "buildspecs/destroy-buildspec.yml"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["uat"]
 
   repository_name      = "bichard7-next-infrastructure"
   sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
@@ -255,7 +255,7 @@ module "run_load_test_migrations" {
   repository_name      = "bichard7-next-infrastructure"
   sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn = module.codebuild_base_resources.notifications_arn
-  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_blocks["uat"]
 
   build_timeout = 180
 
@@ -330,7 +330,7 @@ module "apply_dev_sg_to_load_test" {
   build_description      = "Codebuild Pipeline for rebuilding terraform infrastructure"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "apply-dev-sgs-to-load-test"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["uat"]
 
   buildspec_file       = "buildspecs/vpc-sg-access.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -384,7 +384,7 @@ module "remove_dev_sg_from_load_test" {
   build_description      = "Codebuild Pipeline for rebuilding terraform infrastructure"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "remove-dev-sgs-from-load-test"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["uat"]
 
   buildspec_file       = "buildspecs/vpc-sg-access.yml"
   repository_name      = "bichard7-next-infrastructure"

--- a/terraform/shared_account_pathtolive_infra_ci/build_preprod.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_preprod.tf
@@ -8,7 +8,7 @@ module "deploy_preprod_terraform" {
   buildspec_file         = "buildspecs/buildspec.yml"
   sns_kms_key_arn        = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn   = module.codebuild_base_resources.notifications_arn
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["pre-prod"]
 
   build_environments = local.pipeline_build_environments
 
@@ -172,7 +172,7 @@ module "destroy_preprod_terraform" {
   build_description      = "Codebuild Pipeline for rebuilding terraform infrastructure"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "destroy-qsolution-preprod"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["pre-prod"]
 
   buildspec_file       = "buildspecs/destroy-buildspec.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -365,7 +365,7 @@ module "run_preprod_migrations" {
   repository_name      = "bichard7-next-infrastructure"
   sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn = module.codebuild_base_resources.notifications_arn
-  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_blocks["pre-prod"]
 
   build_timeout = 180
 
@@ -445,7 +445,7 @@ module "deploy_preprod_conductor_definitions" {
   repository_name      = "bichard7-next-infrastructure"
   sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn = module.codebuild_base_resources.notifications_arn
-  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_blocks["pre-prod"]
 
   build_timeout = 180
 
@@ -503,7 +503,7 @@ module "apply_dev_sg_to_preprod" {
   build_description      = "Codebuild Pipeline for rebuilding terraform infrastructure"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "apply-dev-sgs-to-preprod"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["pre-prod"]
 
   buildspec_file       = "buildspecs/vpc-sg-access.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -557,7 +557,7 @@ module "remove_dev_sg_from_preprod" {
   build_description      = "Codebuild Pipeline for rebuilding terraform infrastructure"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "remove-dev-sgs-from-preprod"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["pre-prod"]
 
   buildspec_file       = "buildspecs/vpc-sg-access.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -620,7 +620,7 @@ module "enable_maintenance_page_preprod" {
   build_description      = "Codebuild Pipeline for enabling maintenance page in preprod"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "enable-maintenance-page-preprod"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["pre-prod"]
 
   buildspec_file       = "buildspecs/maintenance-buildspec.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -664,7 +664,7 @@ module "disable_maintenance_page_preprod" {
   build_description      = "Codebuild Pipeline for disabling maintenance page in preprod"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "disable-maintenance-page-preprod"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["pre-prod"]
 
   buildspec_file       = "buildspecs/maintenance-buildspec.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -707,7 +707,7 @@ module "enable_pnc_test_tool" {
   build_description      = "Enable PNC test tool in pre production"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "enable-pnc-test-tool"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["pre-prod"]
 
   buildspec_file       = "buildspecs/pnc-test-tool-buildspec.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -763,7 +763,7 @@ module "disable_pnc_test_tool" {
   build_description      = "Disable PNC test tool in pre production"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "disable-pnc-test-tool"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["pre-prod"]
 
 
   buildspec_file       = "buildspecs/pnc-test-tool-buildspec.yml"

--- a/terraform/shared_account_pathtolive_infra_ci/build_production.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_production.tf
@@ -8,7 +8,7 @@ module "deploy_production_terraform" {
   buildspec_file         = "buildspecs/buildspec.yml"
   sns_kms_key_arn        = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn   = module.codebuild_base_resources.notifications_arn
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["production"]
   event_type_ids         = []
 
   build_environments = local.pipeline_build_environments
@@ -224,7 +224,7 @@ module "destroy_production_terraform" {
   build_description      = "Codebuild Pipeline for rebuilding terraform infrastructure"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "destroy-qsolution-production"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["production"]
 
   buildspec_file       = "buildspecs/destroy-buildspec.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -354,7 +354,7 @@ module "apply_dev_sg_to_prod" {
   build_description      = "Codebuild Pipeline for rebuilding terraform infrastructure"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "apply-dev-sgs-to-prod"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["production"]
 
   buildspec_file       = "buildspecs/vpc-sg-access.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -408,7 +408,7 @@ module "remove_dev_sg_from_prod" {
   build_description      = "Codebuild Pipeline for rebuilding terraform infrastructure"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "remove-dev-sgs-from-prod"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["production"]
 
   buildspec_file       = "buildspecs/vpc-sg-access.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -476,7 +476,7 @@ module "run_production_migrations" {
   repository_name      = "bichard7-next-infrastructure"
   sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn = module.codebuild_base_resources.notifications_arn
-  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_blocks["production"]
 
   build_timeout = 180
 
@@ -556,7 +556,7 @@ module "deploy_production_conductor_definitions" {
   repository_name      = "bichard7-next-infrastructure"
   sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn = module.codebuild_base_resources.notifications_arn
-  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_blocks["production"]
 
   build_timeout = 180
 
@@ -614,7 +614,7 @@ module "enable_maintenance_page_prod" {
   build_description      = "Codebuild Pipeline for enabling maintenance page in prod"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "enable-maintenance-page-prod"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["production"]
 
   buildspec_file       = "buildspecs/maintenance-buildspec.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -658,7 +658,7 @@ module "disable_maintenance_page_prod" {
   build_description      = "Codebuild Pipeline for disabling maintenance page in prod"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "disable-maintenance-page-prod"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["production"]
 
   buildspec_file       = "buildspecs/maintenance-buildspec.yml"
   repository_name      = "bichard7-next-infrastructure"

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -8,7 +8,7 @@ module "deploy_uat_terraform" {
   buildspec_file         = "buildspecs/buildspec.yml"
   sns_kms_key_arn        = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn   = module.codebuild_base_resources.notifications_arn
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["uat"]
 
   build_environments = local.pipeline_build_environments
 
@@ -161,7 +161,7 @@ module "destroy_uat_test_terraform" {
   repository_name      = "bichard7-next-infrastructure"
   sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn = module.codebuild_base_resources.notifications_arn
-  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_blocks["uat"]
 
   build_timeout = 180
 
@@ -254,7 +254,7 @@ module "run_uat_migrations" {
   repository_name      = "bichard7-next-infrastructure"
   sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn = module.codebuild_base_resources.notifications_arn
-  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_blocks["uat"]
 
   build_timeout = 180
 
@@ -334,7 +334,7 @@ module "deploy_uat_conductor_definitions" {
   repository_name      = "bichard7-next-infrastructure"
   sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn = module.codebuild_base_resources.notifications_arn
-  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_blocks["uat"]
 
   build_timeout = 180
 
@@ -392,7 +392,7 @@ module "apply_dev_sg_to_uat" {
   build_description      = "Codebuild Pipeline for rebuilding terraform infrastructure"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "apply-dev-sgs-to-uat"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["uat"]
 
   buildspec_file       = "buildspecs/vpc-sg-access.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -446,7 +446,7 @@ module "remove_dev_sg_from_uat" {
   build_description      = "Codebuild Pipeline for rebuilding terraform infrastructure"
   codepipeline_s3_bucket = module.codebuild_base_resources.codepipeline_bucket
   name                   = "remove-dev-sgs-from-uat"
-  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config             = module.codebuild_base_resources.codebuild_vpc_config_blocks["uat"]
 
   buildspec_file       = "buildspecs/vpc-sg-access.yml"
   repository_name      = "bichard7-next-infrastructure"
@@ -505,7 +505,7 @@ module "seed_uat_environment" {
   repository_name      = "bichard7-next-core"
   sns_kms_key_arn      = module.codebuild_base_resources.notifications_kms_key_arn
   sns_notification_arn = module.codebuild_base_resources.notifications_arn
-  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_block
+  vpc_config           = module.codebuild_base_resources.codebuild_vpc_config_blocks["uat"]
 
   environment_variables = [
     {

--- a/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
@@ -3,6 +3,7 @@ module "run_e2e_tests" {
   name              = "integration-test-e2e-test"
   build_description = "Codebuild Pipeline Running integration tests against e2e-test"
   repository_name   = "bichard7-next-core"
+  vpc_config        = module.codebuild_base_resources.codebuild_vpc_config_blocks["e2e-test"]
 
   report_build_status = true
 

--- a/terraform/shared_account_pathtolive_infra_ci/main.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/main.tf
@@ -31,7 +31,8 @@ module "codebuild_base_resources" {
   name            = module.label.name
   slack_webhook   = var.slack_webhook
 
-  allow_accounts = local.shared_resource_accounts
+  allow_accounts                 = local.shared_resource_accounts
+  codebuild_sg_environment_names = ["production", "pre-prod", "e2e-test", "uat"]
 
   tags = module.label.tags
 }

--- a/terraform/shared_account_pathtolive_infra_ci/outputs.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/outputs.tf
@@ -48,6 +48,11 @@ output "codebuild_security_group_id" {
   value       = module.codebuild_base_resources.codebuild_security_group_id
 }
 
+output "codebuild_security_group_ids" {
+  description = "The VPC security group ids used by codebuild"
+  value       = module.codebuild_base_resources.codebuild_security_group_ids
+}
+
 output "bichard_liberty_ecr" {
   description = "The Bichard Liberty ecr repository details"
   value       = module.codebuild_docker_resources.bichard_liberty_ecr


### PR DESCRIPTION
This PR implements separate security groups for each environment within the shared account. These security groups are assigned to CodeBuild jobs that require access to the corresponding environment’s resources via VPC peering.

Currently, a single security group is used for all CodeBuild jobs, allowing them to access all environments. By introducing distinct security groups, access can be restricted, ensuring each CodeBuild job only has the necessary permissions for its designated environment.