### PR TITLE
Add VPC config for run preprod tests job

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/build_preprod.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_preprod.tf
@@ -293,6 +293,7 @@ module "run_preprod_tests" {
   name              = "integration-test-preprod"
   build_description = "Codebuild Pipeline Running integration tests against preprod"
   repository_name   = "bichard7-next-core"
+  vpc_config        = module.codebuild_base_resources.codebuild_vpc_config_blocks["pre-prod"]
 
   report_build_status = true
 


### PR DESCRIPTION
PR to add VPC config for run preprod tests codebuild job. This allows accessing resource in preprod environment via VPC peering.