### PR TITLE
Update e2e test jobs to use Codebuild 2023 Base image

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/build_e2e_test_environments.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_e2e_test_environments.tf
@@ -12,7 +12,7 @@ module "deploy_e2e_test_terraform" {
 
   build_timeout = 180
 
-  build_environments = local.pipeline_build_environments
+  build_environments = local.codebuild_2023_pipeline_build_environments
 
   codebuild_secondary_sources = [
     {
@@ -140,7 +140,7 @@ module "destroy_e2e_test_terraform" {
   deploy_account_name = "integration_next"
   deployment_name     = "e2e-test"
 
-  build_environments = local.pipeline_build_environments
+  build_environments = local.codebuild_2023_pipeline_build_environments
 
   allowed_resource_arns = [
     module.codebuild_docker_resources.liquibase_repository_arn,
@@ -375,7 +375,7 @@ module "apply_dev_sg_to_e2e_test" {
 
   build_timeout = 180
 
-  build_environments = local.pipeline_build_environments
+  build_environments = local.codebuild_2023_pipeline_build_environments
 
   deploy_account_name = "integration_next"
   deployment_name     = "e2e-test"
@@ -430,7 +430,7 @@ module "remove_dev_sg_from_e2e_test" {
 
   build_timeout = 180
 
-  build_environments = local.pipeline_build_environments
+  build_environments = local.codebuild_2023_pipeline_build_environments
 
   deploy_account_name = "integration_next"
   deployment_name     = "e2e-test"

--- a/terraform/shared_account_pathtolive_infra_ci/build_preprod.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_preprod.tf
@@ -307,7 +307,7 @@ module "run_preprod_tests" {
     module.codebuild_docker_resources.codebuild_2023_base.arn
   ]
 
-  build_environments = local.pipeline_build_environments
+  build_environments = local.codebuild_2023_pipeline_build_environments
 
   environment_variables = [
     {

--- a/terraform/shared_account_pathtolive_infra_ci/data.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/data.tf
@@ -66,10 +66,30 @@ data "aws_ecr_repository" "codebuild_base" {
   ]
 }
 
+data "aws_ecr_repository" "codebuild_2023_base" {
+  name = "codebuild-2023-base"
+
+  depends_on = [
+    module.codebuild_base_resources
+  ]
+}
+
 data "external" "latest_codebuild_base" {
   program = [
     "aws", "ecr", "describe-images",
     "--repository-name", data.aws_ecr_repository.codebuild_base.name,
+    "--query", "{\"tags\": to_string(sort_by(imageDetails,& imagePushedAt)[-1].imageDigest)}",
+  ]
+
+  depends_on = [
+    module.codebuild_base_resources
+  ]
+}
+
+data "external" "latest_codebuild_2023_base" {
+  program = [
+    "aws", "ecr", "describe-images",
+    "--repository-name", data.aws_ecr_repository.codebuild_2023_base.name,
     "--query", "{\"tags\": to_string(sort_by(imageDetails,& imagePushedAt)[-1].imageDigest)}",
   ]
 

--- a/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/e2e_tests.tf
@@ -15,14 +15,7 @@ module "run_e2e_tests" {
     module.codebuild_docker_resources.codebuild_2023_base.arn
   ]
 
-  build_environments = [
-    {
-      compute_type    = "BUILD_GENERAL1_MEDIUM"
-      image           = "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
-      type            = "LINUX_CONTAINER"
-      privileged_mode = true
-    }
-  ]
+  build_environments = local.codebuild_2023_pipeline_build_environments
 
   environment_variables = [
     {

--- a/terraform/shared_account_pathtolive_infra_ci/locals.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/locals.tf
@@ -56,6 +56,17 @@ locals {
     }
   ]
 
+  codebuild_2023_pipeline_build_environments = [
+    {
+      compute_type                = "BUILD_GENERAL1_MEDIUM"
+      type                        = "LINUX_CONTAINER"
+      privileged_mode             = true
+      image                       = "${data.aws_ecr_repository.codebuild_2023_base.repository_url}@${data.external.latest_codebuild_2023_base.result.tags}"
+      image_pull_credentials_type = "SERVICE_ROLE"
+
+    }
+  ]
+
   vpn_rotation_vars = [
     {
       id                  = data.aws_caller_identity.integration_next.account_id


### PR DESCRIPTION
This PR updates the following Codebuild jobs to use Codebuild 2023 Base image:
- `deploy-integration-next-e2e-test`
- `destroy-integration-next-e2e-test`
- `run-e2e-test-migrations`
- `apply-dev-sgs-to-e2e-test`
- `remove-dev-sgs-from-e2e-test`
- `integration-test-preprod`