### PR TITLE
Bump compute size for conductor image codebuild

### DIFF
--- a/terraform/modules/shared_cd_common_jobs/build_conductor_image.tf
+++ b/terraform/modules/shared_cd_common_jobs/build_conductor_image.tf
@@ -13,6 +13,15 @@ module "build_conductor_image" {
   sns_kms_key_arn        = var.notifications_kms_key_arn
   vpc_config             = var.vpc_config_block
 
+  build_environments = [
+    {
+      compute_type    = "BUILD_GENERAL1_MEDIUM"
+      image           = "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
+      type            = "LINUX_CONTAINER"
+      privileged_mode = true
+    }
+  ]
+
   tags = var.tags
 }
 


### PR DESCRIPTION
The image build for Conductor had been consistently failing, likely due to insufficient memory. To address this, we increased the compute resource size. We tested this with an override to use the new resource, and it has seemed to have resolved the failures and also reduced build times, making the trade-off in resource usage worthwhile.