### PR TITLE
Use amazon linux 2 for building Conductor and Beanconnect image

### DIFF
--- a/terraform/modules/shared_cd_common_jobs/build_beanconnect.tf
+++ b/terraform/modules/shared_cd_common_jobs/build_beanconnect.tf
@@ -8,6 +8,16 @@ module "build_bichard7_beanconnect_docker_image" {
   repository_name        = "bichard7-next-beanconnect"
   vpc_config             = var.vpc_config_block
 
+
+  build_environments = [
+    {
+      compute_type    = "BUILD_GENERAL1_SMALL"
+      image           = "aws/codebuild/amazonlinux-x86_64-standard:4.0"
+      type            = "LINUX_CONTAINER"
+      privileged_mode = true
+    }
+  ]
+
   environment_variables = var.beanconnect_cd_env_vars
 
   tags = var.tags

--- a/terraform/modules/shared_cd_common_jobs/build_conductor_image.tf
+++ b/terraform/modules/shared_cd_common_jobs/build_conductor_image.tf
@@ -16,7 +16,7 @@ module "build_conductor_image" {
   build_environments = [
     {
       compute_type    = "BUILD_GENERAL1_MEDIUM"
-      image           = local.amazon_linux_2023
+      image           = "aws/codebuild/amazonlinux-x86_64-standard:4.0"
       type            = "LINUX_CONTAINER"
       privileged_mode = true
     }


### PR DESCRIPTION
We need to use the old amazon linux 2 image until we sort out the issue with Docker versions.
Amazon linux 2 is using v20.10.24 and Amazon linux 2023 is using v27.3.1
A [ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/BICAWS7/boards/1368/backlog?selectedIssue=BICAWS7-3673) has been created to sort this issue 
