### PR TITLE
Use SSM for NIAM API Gateway target

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/build_leds_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_leds_environment.tf
@@ -106,10 +106,6 @@ module "deploy_leds_test_environment_terraform" {
     {
       name  = "TF_VAR_aurora_db_version"
       value = "15.12"
-    },
-    {
-      name  = "TF_VAR_niam_api_url"
-      value = "https://login.microsoftonline.com/25d6f0c9-a61a-4999-9b67-4babac41824f/oauth2/v2.0/token"
     }
   ]
 

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -516,7 +516,7 @@ resource "aws_codepipeline" "path_to_live" {
               value = "true"
             },
             {
-              name = "TF_VAR_use_ssm_for_niam_api_gateway_target"
+              name  = "TF_VAR_use_ssm_for_niam_api_gateway_target"
               value = "true"
             }
           ]

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -514,6 +514,10 @@ resource "aws_codepipeline" "path_to_live" {
             {
               name  = "TF_VAR_deploy_leds_api_tgw_routes"
               value = "true"
+            },
+            {
+              name = "TF_VAR_use_ssm_for_niam_api_gateway_target"
+              value = true
             }
           ]
         )

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -517,7 +517,7 @@ resource "aws_codepipeline" "path_to_live" {
             },
             {
               name = "TF_VAR_use_ssm_for_niam_api_gateway_target"
-              value = true
+              value = "true"
             }
           ]
         )


### PR DESCRIPTION
This PR removes the NIAM API URL environment variable and sets `TF_VAR_use_ssm_for_niam_api_gateway_target`, so that the URL stored in the SSM parameter is used for the NIAM API Gateway target.