### PR TITLE
Deploy LEDS resources to preprod environment

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -760,7 +760,7 @@ resource "aws_codepipeline" "path_to_live" {
             },
             {
               name  = "TF_VAR_use_ssm_for_niam_api_gateway_target"
-              value = false
+              value = "false"
             }
           ]
         )

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -733,6 +733,34 @@ resource "aws_codepipeline" "path_to_live" {
             {
               name  = "TF_VAR_api_deploy_tag"
               value = "#{HASHES.API_IMAGE_HASH}"
+            },
+            {
+              name  = "TF_VAR_leds_integration_mode"
+              value = "real"
+            },
+            {
+              name  = "TF_VAR_use_leds"
+              value = "false"
+            },
+            {
+              name  = "TF_VAR_leds_proxy_skip_ssl_verification"
+              value = "true"
+            },
+            {
+              name  = "TF_VAR_deploy_private_hosted_zone_association"
+              value = "false"
+            },
+            {
+              name  = "TF_VAR_deploy_tgw_attachment"
+              value = "false"
+            },
+            {
+              name  = "TF_VAR_deploy_leds_api_tgw_routes"
+              value = "false"
+            },
+            {
+              name = "TF_VAR_use_ssm_for_niam_api_gateway_target"
+              value = false
             }
           ]
         )

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -759,7 +759,7 @@ resource "aws_codepipeline" "path_to_live" {
               value = "false"
             },
             {
-              name = "TF_VAR_use_ssm_for_niam_api_gateway_target"
+              name  = "TF_VAR_use_ssm_for_niam_api_gateway_target"
               value = false
             }
           ]


### PR DESCRIPTION
This PR sets environment variables in the `deploy-preprod-environment` AWS pipeline action to deploy LEDS resources to the Preprod environment.

Environment variables:

- **`TF_VAR_leds_integration_mode=real`:**
This variable is used in the deployment script to deploy the `leds` layer (resources to integrate with the real LEDS API).  

- **`TF_VAR_use_leds=false`:**
This explicitly indicates not to use LEDS, meaning the Core Worker will not utilise LEDS. It will remain set to `false` until we switch over to LEDS.  

- **`TF_VAR_leds_proxy_skip_ssl_verification=true`:**
This option skips SSL verification for mTLS communication between the LEDS proxy Lambda and the LEDS API.  

- **`TF_VAR_deploy_private_hosted_zone_association=false`:**
This prevents the deployment of the Private Hosted Zone (PHZ) association. We will set it to `true` once we have configured the PHZ ID we want to associate with in SSM.  

- **`TF_VAR_deploy_tgw_attachment=false`:**
This disables the deployment of the Transit Gateway (TGW) attachment. We will change this to `true` once we have specified the TGW invitation ARN and TGW ID in SSM.  

- **`TF_VAR_deploy_leds_api_tgw_routes=false`:**
This variable stops updates to the VPC route table for the LEDS API. It will be set to `true` once we have defined the LEDS API CIDR in SSM.  

- **`TF_VAR_use_ssm_for_niam_api_gateway_target=false`:**
This sets the NIAM API Gateway target to a placeholder URL. We will update this to `true` once the public NIAM API URL is configured in SSM.  