### PR TITLE
Add a new action to run LEDS tests in the pipeline

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -634,6 +634,21 @@ resource "aws_codepipeline" "path_to_live" {
         "core"
       ]
     }
+
+    action {
+      category  = "Build"
+      name      = "run-leds-tests"
+      owner     = "AWS"
+      provider  = "CodeBuild"
+      version   = "1"
+      run_order = 5
+
+      configuration = {
+        ProjectName = module.run_leds_tests.pipeline_name
+      }
+
+      input_artifacts = ["core"]
+    }
   }
 
   stage {

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live_iam.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live_iam.tf
@@ -211,6 +211,12 @@ resource "aws_iam_role_policy" "deploy_leds_test_environment_terraform" {
   role   = module.deploy_leds_test_environment_terraform.pipeline_service_role_name
 }
 
+resource "aws_iam_role_policy" "run_leds_tests" {
+  name   = "allow-codestar-connection"
+  policy = local.allow_codebuild_codestar_connection_policy
+  role   = module.run_leds_tests.pipeline_service_role_name
+}
+
 resource "aws_iam_role_policy" "run_leds_test_migrations" {
   name   = "allow-codestar-connection"
   policy = local.allow_codebuild_codestar_connection_policy


### PR DESCRIPTION
This PR adds a new action to our AWS pipeline to run LEDS e2e tests.