### PR TITLE
BICAWS7-4187 - Allow smoke tests codebuild to access connectivity key

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/data.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/data.tf
@@ -141,3 +141,13 @@ data "external" "latest_zap_owasp_scanner" {
 data "aws_secretsmanager_secret_version" "github_token" {
   secret_id = aws_secretsmanager_secret.github_token.id
 }
+
+data "aws_secretsmanager_secret" "production_connectivity_check_key" {
+  provider = aws.production
+  name     = "bichard-7-production-connectivity-check-key"
+}
+
+data "aws_kms_alias" "production_connectivity_check_key" {
+  provider = aws.production
+  name     = "alias/production-connectivity-check-key"
+}

--- a/terraform/shared_account_pathtolive_infra_ci/policies/retrieve_secret_value_policy.json
+++ b/terraform/shared_account_pathtolive_infra_ci/policies/retrieve_secret_value_policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowReadingCrossAccountSecret",
+      "Effect": "Allow",
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "${secret_arn}"
+    },
+    {
+      "Sid": "AllowDecryptingCrossAccountSecret",
+      "Effect": "Allow",
+      "Action": "kms:Decrypt",
+      "Resource": "${key_arn}"
+    }
+  ]
+}

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -1625,6 +1625,11 @@ module "run_prod_smoketests" {
     {
       name  = "AWS_ACCOUNT_NAME"
       value = "production"
+    },
+    {
+      name  = "CONNECTIVITY_CHECK_KEY"
+      value = data.aws_secretsmanager_secret.production_connectivity_check_key.arn
+      type  = "SECRETS_MANAGER"
     }
   ]
   tags = module.label.tags

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live_iam.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live_iam.tf
@@ -97,6 +97,29 @@ resource "aws_iam_role_policy" "allow_code_pipeline_connection_for_production_sm
   role   = module.run_prod_smoketests.pipeline_service_role_name
 }
 
+data "aws_secretsmanager_secret" "production_connectivity_check_key" {
+  provider = aws.production
+  name     = "bichard-7-production-connectivity-check-key"
+}
+
+data "aws_kms_alias" "production_connectivity_check_key" {
+  provider = aws.production
+  name     = "alias/production-connectivity-check-key"
+}
+
+resource "aws_iam_role_policy" "retrieve_connectivity_api_key_for_production_smoketests" {
+  name   = "Retrieve-Connectivity-API-Key"
+  role   = module.run_prod_smoketests.pipeline_service_role_name
+
+  policy = templatefile(
+    "${path.module}/policies/retrieve_secret_value_policy.json",
+    {
+      secret_arn = data.aws_secretsmanager_secret.production_connectivity_check_key.arn
+      key_arn    = data.aws_kms_alias.production_connectivity_check_key.arn
+    }
+  )
+}
+
 resource "aws_iam_role_policy" "allow_code_pipeline_connection_for_load_tests" {
   name   = "Allow-Codestar-Connection"
   policy = local.allow_codebuild_codestar_connection_policy

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live_iam.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live_iam.tf
@@ -97,16 +97,6 @@ resource "aws_iam_role_policy" "allow_code_pipeline_connection_for_production_sm
   role   = module.run_prod_smoketests.pipeline_service_role_name
 }
 
-data "aws_secretsmanager_secret" "production_connectivity_check_key" {
-  provider = aws.production
-  name     = "bichard-7-production-connectivity-check-key"
-}
-
-data "aws_kms_alias" "production_connectivity_check_key" {
-  provider = aws.production
-  name     = "alias/production-connectivity-check-key"
-}
-
 resource "aws_iam_role_policy" "retrieve_connectivity_api_key_for_production_smoketests" {
   name = "Retrieve-Connectivity-API-Key"
   role = module.run_prod_smoketests.pipeline_service_role_name

--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live_iam.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live_iam.tf
@@ -108,8 +108,8 @@ data "aws_kms_alias" "production_connectivity_check_key" {
 }
 
 resource "aws_iam_role_policy" "retrieve_connectivity_api_key_for_production_smoketests" {
-  name   = "Retrieve-Connectivity-API-Key"
-  role   = module.run_prod_smoketests.pipeline_service_role_name
+  name = "Retrieve-Connectivity-API-Key"
+  role = module.run_prod_smoketests.pipeline_service_role_name
 
   policy = templatefile(
     "${path.module}/policies/retrieve_secret_value_policy.json",


### PR DESCRIPTION
As this only runs on prod, it only needs access to the secret in the production environment