### PR TITLE
BICAWS7-4178 - Use target_key_arn to resolve KMS cross account issue

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live_iam.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live_iam.tf
@@ -105,7 +105,7 @@ resource "aws_iam_role_policy" "retrieve_connectivity_api_key_for_production_smo
     "${path.module}/policies/retrieve_secret_value_policy.json",
     {
       secret_arn = data.aws_secretsmanager_secret.production_connectivity_check_key.arn
-      key_arn    = data.aws_kms_alias.production_connectivity_check_key.arn
+      key_arn    = data.aws_kms_alias.production_connectivity_check_key.target_key_arn
     }
   )
 }


### PR DESCRIPTION
KMS aliases cannot be resolved across accounts so I need to add the true ARN of the KMS key to the IAM policy in order for the smoke tests to be able to use it.