### PR TITLE
BICAWS7-4234 - Add env variable for desired UI instance count

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/build_leds_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_leds_environment.tf
@@ -92,6 +92,10 @@ module "deploy_leds_test_environment_terraform" {
       value = 3 # One per AZ
     },
     {
+      name  = "TF_VAR_desired_ui_instance_count"
+      value = 3 # One per AZ
+    },
+    {
       name  = "TF_VAR_desired_user_service_instance_count"
       value = 3 # One per AZ
     },

--- a/terraform/shared_account_pathtolive_infra_ci/build_load_test_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_load_test_environment.tf
@@ -104,6 +104,10 @@ module "deploy_load_test_terraform" {
       value = 3 # One per AZ
     },
     {
+      name  = "TF_VAR_desired_ui_instance_count"
+      value = 3 # One per AZ
+    },
+    {
       name  = "TF_VAR_desired_user_service_instance_count"
       value = 3 # One per AZ
     },

--- a/terraform/shared_account_pathtolive_infra_ci/build_production.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_production.tf
@@ -163,6 +163,10 @@ module "deploy_production_terraform" {
       value = 3 # One per AZ
     },
     {
+      name  = "TF_VAR_desired_ui_instance_count"
+      value = 3 # One per AZ
+    },
+    {
       name  = "TF_VAR_desired_user_service_instance_count"
       value = 3 # One per AZ
     },

--- a/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/build_uat_environment.tf
@@ -106,6 +106,10 @@ module "deploy_uat_terraform" {
       value = 3 # One per AZ
     },
     {
+      name  = "TF_VAR_desired_ui_instance_count"
+      value = 3 # One per AZ
+    },
+    {
       name  = "TF_VAR_desired_user_service_instance_count"
       value = 3 # One per AZ
     },


### PR DESCRIPTION
We want to add this so we can use it for a CloudWatch alarm (and also control the instance count properly per env). 