### PR TITLE
Pin urllib3 for IAM Access Key Audit workflow

### DIFF
--- a/.github/workflows/check-access-key-age.yml
+++ b/.github/workflows/check-access-key-age.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: "3.11"
 
       - name: ⛓️ SLSA Supply Chain Security
-        uses: ministryofjustice/devsecops-actions/sca/slsa@2ce4e5898dfb83378215b4ae15401d4e9dba0649 # v1.4.0
+        uses: ministryofjustice/devsecops-actions/sca/slsa@8c77d3a65a46d1d4b5416eafae5b84371ecd797d # v1.5.0
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/check-access-key-age.yml
+++ b/.github/workflows/check-access-key-age.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
+        with:
+          fetch-depth: 2
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
@@ -28,10 +30,22 @@ jobs:
           python-version: "3.11"
 
       - name: ⛓️ SLSA Supply Chain Security
+        id: slsa
         uses: ministryofjustice/devsecops-actions/sca/slsa@2ce4e5898dfb83378215b4ae15401d4e9dba0649 # v1.4.0
+        continue-on-error: true
+
+      - name: Install Fallback Dependencies
+        if: steps.slsa.outcome == 'failure'
+        run: |
+          echo "SLSA check failed. Reverting to previous version..."
+          git checkout HEAD^1 -- requirements.txt
+          pip install -r requirements.txt
 
       - name: Install Dependencies
-        run: pip install -r requirements.txt
+        if: steps.slsa.outcome == 'success'
+        run: |
+          echo "SLSA check passed."
+          pip install -r requirements.txt
 
       - name: Run Audit Script
         shell: bash
@@ -44,15 +58,23 @@ jobs:
         run: |
           python3 check_access_key_age.py
 
-# Temporarily disabled - investigating alternatives
-#      - name: Report Status
-#        if: always()
-#        uses: ravsamhq/notify-slack-action@4ed28566c2bdcdaee6dca2b46b9666d01b4ed8a4 # v1
-#        with:
-#          status: ${{ job.status }}
-#          notification_title: 'GitHub action failed'
-#          message_format: ':elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>'
-#          notify_when: 'failure'
-#          footer: 'Linked to Repo <{repo_url}|{repo}>'
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+      - name: Report Status
+        if: failure()
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d #v2.0.0
+        with:
+          webhook-type: incoming-webhook
+          payload: |
+            text: "GitHub action failed"
+            attachments:
+              - color: "#a30000" # Red
+                blocks:
+                  - type: "section"
+                    text:
+                      type: "mrkdwn"
+                      text: ":elmo-fire: *${{ github.workflow }}* failed in <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>"
+                  - type: "context"
+                    elements:
+                      - type: "mrkdwn"
+                        text: "Linked to Repo <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.github/workflows/check-access-key-age.yml
+++ b/.github/workflows/check-access-key-age.yml
@@ -33,8 +33,7 @@ jobs:
         uses: ministryofjustice/devsecops-actions/sca/slsa@8c77d3a65a46d1d4b5416eafae5b84371ecd797d # v1.5.0
 
       - name: Install Dependencies
-        run: |
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Run Audit Script
         shell: bash
@@ -44,8 +43,7 @@ jobs:
           ACCESS_KEY_WARN_AGE_DAYS: 70
           ACCESS_KEY_EXPIRY_AGE_DAYS: 90
           SLACK_CHANNEL_NAME: "moj-cjse-bichard-alerts"
-        run: |
-          python3 check_access_key_age.py
+        run: python3 check_access_key_age.py
 
       - name: Report Status
         if: failure()

--- a/.github/workflows/check-access-key-age.yml
+++ b/.github/workflows/check-access-key-age.yml
@@ -33,16 +33,7 @@ jobs:
         uses: ministryofjustice/devsecops-actions/sca/slsa@2ce4e5898dfb83378215b4ae15401d4e9dba0649 # v1.4.0
 
       - name: Install Dependencies
-        id: install_deps
-        continue-on-error: true
         run: |
-          pip install -r requirements.txt
-
-      - name: Install Fallback Dependencies
-        if: steps.install_deps.outcome == 'failure'
-        run: |
-          echo "Reverting to previous version..."
-          git checkout HEAD^1 -- requirements.txt
           pip install -r requirements.txt
 
       - name: Run Audit Script

--- a/.github/workflows/check-access-key-age.yml
+++ b/.github/workflows/check-access-key-age.yml
@@ -30,21 +30,19 @@ jobs:
           python-version: "3.11"
 
       - name: ⛓️ SLSA Supply Chain Security
-        id: slsa
-        uses: ministryofjustice/devsecops-actions/sca/slsa@8c77d3a65a46d1d4b5416eafae5b84371ecd797d # v1.5.0
-        continue-on-error: true
-
-      - name: Install Fallback Dependencies
-        if: steps.slsa.outcome == 'failure'
-        run: |
-          echo "SLSA check failed. Reverting to previous version..."
-          git checkout HEAD^1 -- requirements.txt
-          pip install -r requirements.txt
+        uses: ministryofjustice/devsecops-actions/sca/slsa@2ce4e5898dfb83378215b4ae15401d4e9dba0649 # v1.4.0
 
       - name: Install Dependencies
-        if: steps.slsa.outcome == 'success'
+        id: install_deps
+        continue-on-error: true
         run: |
-          echo "SLSA check passed."
+          pip install -r requirements.txt
+
+      - name: Install Fallback Dependencies
+        if: steps.install_deps.outcome == 'failure'
+        run: |
+          echo "Reverting to previous version..."
+          git checkout HEAD^1 -- requirements.txt
           pip install -r requirements.txt
 
       - name: Run Audit Script

--- a/.github/workflows/check-access-key-age.yml
+++ b/.github/workflows/check-access-key-age.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
-        with:
-          fetch-depth: 2
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3==1.42.83
 botocore==1.42.83
 slack-sdk==3.41.0
 s3transfer==0.16.0
+urllib3==2.6.3


### PR DESCRIPTION
Pinning urllib3 due to SLSA quarantine period in IAM Access Key Audit workflow

IAM audit was failing due to the SLSA 72-hour quarantine. I thought I could build a fallback step that'd use requirements.txt from the last commit in the event of a failure, but it was a peer dependency that was breaking the workflow 