### PR TITLE
Fix Failing Deployment Reminder

### DIFF
--- a/deployment-reminder.yml
+++ b/deployment-reminder.yml
@@ -4,7 +4,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      python: 3.11
+      python: 3.11.14
     commands:
       - pip install boto3
       - pip install requests

--- a/deployment-reminder.yml
+++ b/deployment-reminder.yml
@@ -4,7 +4,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      python: 3.9
+      python: 3.11
     commands:
       - pip install boto3
       - pip install requests


### PR DESCRIPTION
Our mild panic bot has been failing due to not being able to install boto3, so the python version has been updated