### PR TITLE
Add dummy deploy tag on plan job

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/plan_e2e_test_environment.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/plan_e2e_test_environment.tf
@@ -95,6 +95,10 @@ module "plan_e2e_test_terraform" {
       name  = "TF_VAR_aurora_db_version"
       value = "15.15"
     },
+    {
+      name  = "TF_VAR_bichard_deploy_tag"
+      value = "unassigned_as_plan" # Hardcode so the plan doesn't fail due to blank SSM params
+    }
   ]
   is_cd = true
 


### PR DESCRIPTION
Terraform expects a deploy tag which is usually injected via the deployment pipeline. As this is a standalone job it won't have this, so hardcoding it. Should be fine to do so as it is only running a plan, no updating infra.

The error:

```

│ Error: Invalid combination of arguments
--
│
│   with module.base_ecs.aws_ssm_parameter.bichard7_deploy_tag,
│   on ../modules/base_ecs/main.tf line 53, in resource "aws_ssm_parameter" "bichard7_deploy_tag":
│   53: resource "aws_ssm_parameter" "bichard7_deploy_tag" {
│
│ "insecure_value": one of `insecure_value,value` must be specified

```