### PR TITLE
Re-enable action: run-leds-tests

### DIFF
--- a/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/promotion_pipeline_path_to_live.tf
@@ -636,24 +636,20 @@ resource "aws_codepipeline" "path_to_live" {
       ]
     }
 
-    # TODO: TEMPORARY BYPASS - REVERT once LEDS gateway routing is fixed.
-    # We are skipping failures in this stage to unblock production deployments
-    # because integration tests are failing most likely due to LEDS routing issues.
+    action {
+      category  = "Build"
+      name      = "run-leds-tests"
+      owner     = "AWS"
+      provider  = "CodeBuild"
+      version   = "1"
+      run_order = 5
 
-    # action {
-    #   category  = "Build"
-    #   name      = "run-leds-tests"
-    #   owner     = "AWS"
-    #   provider  = "CodeBuild"
-    #   version   = "1"
-    #   run_order = 5
+      configuration = {
+        ProjectName = module.run_leds_tests.pipeline_name
+      }
 
-    #   configuration = {
-    #     ProjectName = module.run_leds_tests.pipeline_name
-    #   }
-
-    #   input_artifacts = ["core"]
-    # }
+      input_artifacts = ["core"]
+    }
   }
 
   stage {


### PR DESCRIPTION
Recent configuration changes on the LEDS side caused the integration tests in the pipeline to fail, which in turn blocked production deployments. 
As a temporary measure, we commented out the `run-leds-tests` action to prevent the pipeline from being blocked while the issue was being resolved.

The underlying issue has now been resolved by the LEDS team, and I have verified the fix by rerunning the tests successfully. 

Re-enabling the `run-leds-tests` action so that integration tests against LEDS are running in the pipeline again.