### PR TITLE
BICAWS7-4307 - Remove consolidated shared-infra cloudtrail

### DIFF
--- a/terraform/shared_account_pathtolive_infra/preprod.tf
+++ b/terraform/shared_account_pathtolive_infra/preprod.tf
@@ -41,16 +41,3 @@ module "shared_account_access_preprod" {
     module.shared_account_user_access
   ]
 }
-
-module "shared_account_preprod_lambda_cloudtrail" {
-  source = "../modules/lambda_cloudtrail"
-
-  name           = "q-solution"
-  logging_bucket = module.aws_logs.aws_logs_bucket
-
-  tags = module.label.tags
-
-  providers = {
-    aws = aws.preprod
-  }
-}


### PR DESCRIPTION
The management events and Lambda data events logging is now within the new per-environment cloudtrail resource.