### PR TITLE
BICAWS7-4307 - Remove consolidated lambda cloudtrail

### DIFF
--- a/terraform/shared_account_pathtolive_infra/production.tf
+++ b/terraform/shared_account_pathtolive_infra/production.tf
@@ -41,16 +41,3 @@ module "shared_account_access_production" {
     module.shared_account_user_access
   ]
 }
-
-module "shared_account_production_next_lambda_cloudtrail" {
-  source = "../modules/lambda_cloudtrail"
-
-  name           = "production"
-  logging_bucket = module.aws_logs.aws_logs_bucket
-
-  tags = module.label.tags
-
-  providers = {
-    aws = aws.production
-  }
-}


### PR DESCRIPTION
The management events and Lambda data events logging is now within the new per-environment cloudtrail resource.

paired with: #431 
