### PR TITLE
BICAWS7-4307 - Detach lambda logs s3 bucket from tf state so it is not deleted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,9 @@ commands:
       - run:
           name: Install dependencies
           command: |
-            apk add curl jq python3 make bash py3-pip openssl wget
+            apk add curl jq python3 make bash py3-pip openssl wget aws-cli
             wget https://github.com/tfsec/tfsec/releases/download/v0.39.29/tfsec-linux-amd64 -O /usr/bin/tfsec
             chmod +x /usr/bin/tfsec
-      - run:
-          name: install aws cli
-          command: pip3 install awscli
   terraform_fmt:
     description: Terraform formatting (terraform fmt)
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ workflows:
   test_and_deploy:
     jobs:
       - terraform_test:
-          version: 1.12.1
+          version: 1.8.4
 
 commands:
   install_dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ workflows:
   test_and_deploy:
     jobs:
       - terraform_test:
-          version: 1.4.4
+          version: 1.12.1
 
 commands:
   install_dependencies:

--- a/terraform/shared_account_pathtolive_infra/production.tf
+++ b/terraform/shared_account_pathtolive_infra/production.tf
@@ -16,6 +16,14 @@ module "production_child_access" {
   ]
 }
 
+removed {
+  from = module.shared_account_production_next_lambda_cloudtrail.aws_s3_bucket.lambda_logs_bucket
+
+  lifecycle {
+    destroy = false
+  }
+}
+
 module "shared_account_access_production" {
   source           = "../modules/shared_account_parent_access"
   child_account_id = data.aws_caller_identity.production.account_id


### PR DESCRIPTION
The cloudtrail resource used to populate this s3 bucket has been removed via an earlier PR. This PR removes this s3 bucket from the tf state so we can retain the logs.

Version of terraform used for testing is updated to match .terraform-version, and aws cli installed via apk to fix change in behaviour from old terraform container image.