### PR TITLE
BICAWS7-4289 - Upgrade terraform AWS provider to v6

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "aws" {
     enabled = true
-    version = "0.19.0"
+    version = "0.48.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ tfenv use
 ### Install required tooling for terraform checks
 
 ```shell
-brew install tfsec terraform-docs tflint yamllint jq pre-commit
+brew install tfsec terraform-docs terraform-linters/tap/tflint yamllint jq pre-commit
 ```
 
 ### Install the pre-commit hooks

--- a/terraform/modules/aws_ecr_repositories/versions.tf
+++ b/terraform/modules/aws_ecr_repositories/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/terraform/modules/aws_ecr_repositories/versions.tf
+++ b/terraform/modules/aws_ecr_repositories/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
     local = {

--- a/terraform/modules/codebuild_base_resources/versions.tf
+++ b/terraform/modules/codebuild_base_resources/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
     archive = {

--- a/terraform/modules/codebuild_base_resources/versions.tf
+++ b/terraform/modules/codebuild_base_resources/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/terraform/modules/codebuild_job/versions.tf
+++ b/terraform/modules/codebuild_job/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/terraform/modules/codebuild_job/versions.tf
+++ b/terraform/modules/codebuild_job/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
     local = {

--- a/terraform/modules/codebuild_schedule/versions.tf
+++ b/terraform/modules/codebuild_schedule/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/terraform/modules/codebuild_schedule/versions.tf
+++ b/terraform/modules/codebuild_schedule/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
     local = {

--- a/terraform/modules/codebuild_webhook/versions.tf
+++ b/terraform/modules/codebuild_webhook/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/modules/codebuild_webhook/versions.tf
+++ b/terraform/modules/codebuild_webhook/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
   }

--- a/terraform/modules/codestar_notification/versions.tf
+++ b/terraform/modules/codestar_notification/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/modules/codestar_notification/versions.tf
+++ b/terraform/modules/codestar_notification/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
   }

--- a/terraform/modules/ecs_cluster/versions.tf
+++ b/terraform/modules/ecs_cluster/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/terraform/modules/ecs_cluster/versions.tf
+++ b/terraform/modules/ecs_cluster/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
     local = {

--- a/terraform/modules/ecs_cluster_alb/versions.tf
+++ b/terraform/modules/ecs_cluster_alb/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/modules/ecs_cluster_alb/versions.tf
+++ b/terraform/modules/ecs_cluster_alb/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
   }

--- a/terraform/modules/lambda_cloudtrail/versions.tf
+++ b/terraform/modules/lambda_cloudtrail/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/modules/lambda_cloudtrail/versions.tf
+++ b/terraform/modules/lambda_cloudtrail/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
   }

--- a/terraform/modules/lambda_slack_webhook/versions.tf
+++ b/terraform/modules/lambda_slack_webhook/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/modules/lambda_slack_webhook/versions.tf
+++ b/terraform/modules/lambda_slack_webhook/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
   }

--- a/terraform/modules/self_signed_certificate/versions.tf
+++ b/terraform/modules/self_signed_certificate/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/terraform/modules/self_signed_certificate/versions.tf
+++ b/terraform/modules/self_signed_certificate/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
     tls = {

--- a/terraform/modules/shared_account_child_access/versions.tf
+++ b/terraform/modules/shared_account_child_access/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/modules/shared_account_child_access/versions.tf
+++ b/terraform/modules/shared_account_child_access/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
   }

--- a/terraform/modules/shared_account_parent/versions.tf
+++ b/terraform/modules/shared_account_parent/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/modules/shared_account_parent/versions.tf
+++ b/terraform/modules/shared_account_parent/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
   }

--- a/terraform/modules/shared_account_parent_access/versions.tf
+++ b/terraform/modules/shared_account_parent_access/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/modules/shared_account_parent_access/versions.tf
+++ b/terraform/modules/shared_account_parent_access/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
   }

--- a/terraform/modules/shared_cd_common_jobs/versions.tf
+++ b/terraform/modules/shared_cd_common_jobs/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/modules/shared_cd_common_jobs/versions.tf
+++ b/terraform/modules/shared_cd_common_jobs/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
   }

--- a/terraform/modules/terraform_remote_state/versions.tf
+++ b/terraform/modules/terraform_remote_state/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "6.58.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/modules/terraform_remote_state/versions.tf
+++ b/terraform/modules/terraform_remote_state/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "6.58.0"
     }
   }

--- a/terraform/shared_account_pathtolive_bootstrap/versions.tf
+++ b/terraform/shared_account_pathtolive_bootstrap/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.38.0"
+      version = "6.58.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/shared_account_pathtolive_infra/versions.tf
+++ b/terraform/shared_account_pathtolive_infra/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.38.0"
+      version = "6.58.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/terraform/shared_account_pathtolive_infra_ci/versions.tf
+++ b/terraform/shared_account_pathtolive_infra_ci/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.38.0"
+      version = "6.58.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/terraform/shared_account_pathtolive_infra_ci_monitoring/versions.tf
+++ b/terraform/shared_account_pathtolive_infra_ci_monitoring/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.38.0"
+      version = "6.58.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/terraform/shared_account_sandbox_bootstrap/versions.tf
+++ b/terraform/shared_account_sandbox_bootstrap/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.38.0"
+      version = "6.58.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/shared_account_sandbox_infra/versions.tf
+++ b/terraform/shared_account_sandbox_infra/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.38.0"
+      version = "6.58.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/terraform/shared_account_sandbox_infra_ci/versions.tf
+++ b/terraform/shared_account_sandbox_infra_ci/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.38.0"
+      version = "6.58.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
- Upgrade AWS provider to `6.58.0`
- Upgrade tflint AWS ruleset to `0.48.0`

```
Terraform will perform the following actions:
--
 
# module.aws_logs.aws_s3_bucket_lifecycle_configuration.aws_logs will be updated in-place
~ resource "aws_s3_bucket_lifecycle_configuration" "aws_logs" {
id                                     = "pathtolive-bootstrap-aws-logs"
~ transition_default_minimum_object_size = "varies_by_storage_class" -> "all_storage_classes_128K"
# (3 unchanged attributes hidden)
 
# (1 unchanged block hidden)
}
 
# module.integration_baseline_child_access.module.aws_logs.aws_s3_bucket_lifecycle_configuration.aws_logs will be updated in-place
~ resource "aws_s3_bucket_lifecycle_configuration" "aws_logs" {
id                                     = "account-logging-439237763202-logs"
~ transition_default_minimum_object_size = "varies_by_storage_class" -> "all_storage_classes_128K"
# (3 unchanged attributes hidden)
 
# (1 unchanged block hidden)
}
 
# module.integration_next_child_access.module.aws_logs.aws_s3_bucket_lifecycle_configuration.aws_logs will be updated in-place
~ resource "aws_s3_bucket_lifecycle_configuration" "aws_logs" {
id                                     = "account-logging-581823340673-logs"
~ transition_default_minimum_object_size = "varies_by_storage_class" -> "all_storage_classes_128K"
# (3 unchanged attributes hidden)
 
# (1 unchanged block hidden)
}
 
# module.preprod_child_access.module.aws_logs.aws_s3_bucket_lifecycle_configuration.aws_logs will be updated in-place
~ resource "aws_s3_bucket_lifecycle_configuration" "aws_logs" {
id                                     = "account-logging-071486367987-logs"
~ transition_default_minimum_object_size = "varies_by_storage_class" -> "all_storage_classes_128K"
# (3 unchanged attributes hidden)
 
# (1 unchanged block hidden)
}
 
# module.production_child_access.module.aws_logs.aws_s3_bucket_lifecycle_configuration.aws_logs will be updated in-place
~ resource "aws_s3_bucket_lifecycle_configuration" "aws_logs" {
id                                     = "account-logging-415925668545-logs"
~ transition_default_minimum_object_size = "varies_by_storage_class" -> "all_storage_classes_128K"
# (3 unchanged attributes hidden)
 
# (1 unchanged block hidden)
}
 
Plan: 0 to add, 5 to change, 0 to destroy.
 
Changes to Outputs:
~ delegated_hosted_zone             = {
+ enable_accelerated_recovery = false
id                          = "Z06328632VRZ32O78C0HJ"
name                        = "ptl.bichard7.modernisation-platform.service.justice.gov.uk"
tags                        = {
Environment      = "default"
Name             = "cjse-bichard7-default-pathtolive-bootstrap"
Namespace        = "cjse-bichard7"
account-name     = "bichard7-shared"
application      = "bichard-7"
business-unit    = "CJSE"
environment-name = "pathtolive-shared-infra"
is-production    = "true"
owner            = "moj-bichard7@madetech.com"
provisioned-by   = "shared_account_pathtolive_infra code see make shared-account-pathtolive-infra in Makefile"
region           = "eu-west-2"
source-code      = "https://github.com/ministryofjustice/bichard7-next-shared-infrastructure/tree/main/shared_terraform/shared_account_pathtolive_infra"
}
+ timeouts                    = null
# (9 unchanged attributes hidden)
}
```